### PR TITLE
Crawl to update geom_src properties

### DIFF
--- a/data/421/166/783/421166783.geojson
+++ b/data/421/166/783/421166783.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008702,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2aaa08e54125fac840e8b88da79a0ed",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421166783,
-    "wof:lastmodified":1566643385,
+    "wof:lastmodified":1582360592,
     "wof:name":"Gualan",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/421/166/811/421166811.geojson
+++ b/data/421/166/811/421166811.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008703,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1deabbd64e87f5b96bc2f63fdde1b1bd",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421166811,
-    "wof:lastmodified":1566643384,
+    "wof:lastmodified":1582360592,
     "wof:name":"Santa Cruz Verapaz",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/166/847/421166847.geojson
+++ b/data/421/166/847/421166847.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008704,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ce4f220135990726cd160c0e08a10bf",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421166847,
-    "wof:lastmodified":1566643385,
+    "wof:lastmodified":1582360592,
     "wof:name":"San Pedro La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/167/973/421167973.geojson
+++ b/data/421/167/973/421167973.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008750,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ff0dd0fbd93c369f9d8e08e3a57c7be",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421167973,
-    "wof:lastmodified":1566643391,
+    "wof:lastmodified":1582360592,
     "wof:name":"Jocotenango",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/168/071/421168071.geojson
+++ b/data/421/168/071/421168071.geojson
@@ -224,6 +224,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008753,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"18780d4421a964c246f58692b540dc75",
     "wof:hierarchy":[
         {
@@ -234,7 +237,7 @@
         }
     ],
     "wof:id":421168071,
-    "wof:lastmodified":1566643383,
+    "wof:lastmodified":1582360592,
     "wof:name":"Escuintla",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/169/087/421169087.geojson
+++ b/data/421/169/087/421169087.geojson
@@ -550,6 +550,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008794,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0aeb93f4fa40ea3030f55c77a2ea0c14",
     "wof:hierarchy":[
         {
@@ -561,7 +564,7 @@
         }
     ],
     "wof:id":421169087,
-    "wof:lastmodified":1566643393,
+    "wof:lastmodified":1582360593,
     "wof:name":"Ciudad de Guatemala",
     "wof:parent_id":421191461,
     "wof:placetype":"locality",

--- a/data/421/169/433/421169433.geojson
+++ b/data/421/169/433/421169433.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008810,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a330af535f66c702b215cf3d0cdc5cc2",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421169433,
-    "wof:lastmodified":1566643393,
+    "wof:lastmodified":1582360593,
     "wof:name":"San Juan Sacatepequez",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/169/903/421169903.geojson
+++ b/data/421/169/903/421169903.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"505d667b68d4981e836fc8230e1a4e63",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421169903,
-    "wof:lastmodified":1566643393,
+    "wof:lastmodified":1582360592,
     "wof:name":"Nebaj",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/169/961/421169961.geojson
+++ b/data/421/169/961/421169961.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008831,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d85e9892a93f23611fdbcce4dab996e8",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421169961,
-    "wof:lastmodified":1566643392,
+    "wof:lastmodified":1582360592,
     "wof:name":"Sacapulas",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/169/963/421169963.geojson
+++ b/data/421/169/963/421169963.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008831,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2f4a043b8fe5fb0e782853b8e36e0f8",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421169963,
-    "wof:lastmodified":1566643391,
+    "wof:lastmodified":1582360592,
     "wof:name":"Zunil",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/170/043/421170043.geojson
+++ b/data/421/170/043/421170043.geojson
@@ -171,6 +171,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008834,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ea65349b191c4fc2bf33a6606851bc4",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":421170043,
-    "wof:lastmodified":1566643434,
+    "wof:lastmodified":1582360596,
     "wof:name":"Tactic",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/170/045/421170045.geojson
+++ b/data/421/170/045/421170045.geojson
@@ -212,6 +212,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008834,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a08410d169a089dd9b0a55188ee3dcd2",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":421170045,
-    "wof:lastmodified":1566643434,
+    "wof:lastmodified":1582360596,
     "wof:name":"Zacapa",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/421/170/143/421170143.geojson
+++ b/data/421/170/143/421170143.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008839,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7643835f7ec8e8c3c90d7b5189da9d97",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421170143,
-    "wof:lastmodified":1566643433,
+    "wof:lastmodified":1582360596,
     "wof:name":"Santa Lucia Utatlan",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/170/799/421170799.geojson
+++ b/data/421/170/799/421170799.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008869,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1beb53f8cc684b7a95fa897e7836759",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421170799,
-    "wof:lastmodified":1566643432,
+    "wof:lastmodified":1582360596,
     "wof:name":"Santa Barbara",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/170/801/421170801.geojson
+++ b/data/421/170/801/421170801.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008869,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3abf25eef11022e341bfaadceef05995",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421170801,
-    "wof:lastmodified":1566643434,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/421/170/963/421170963.geojson
+++ b/data/421/170/963/421170963.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008876,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"63ee1cb1ba97dc00bbd7c0bf23c3d250",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421170963,
-    "wof:lastmodified":1566643432,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Andres Semetabaj",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/171/417/421171417.geojson
+++ b/data/421/171/417/421171417.geojson
@@ -234,6 +234,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008893,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56ffee7f52d06914f92e2fe195a45a04",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         }
     ],
     "wof:id":421171417,
-    "wof:lastmodified":1566643451,
+    "wof:lastmodified":1582360597,
     "wof:name":"La Gomera",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/171/421/421171421.geojson
+++ b/data/421/171/421/421171421.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008893,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e541be879d3e493dbaf6a4b0687e1574",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421171421,
-    "wof:lastmodified":1566643451,
+    "wof:lastmodified":1582360597,
     "wof:name":"Tucuru",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/171/679/421171679.geojson
+++ b/data/421/171/679/421171679.geojson
@@ -216,6 +216,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008902,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"003da8aa7ce1d6bc207af1c0c8eff657",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":421171679,
-    "wof:lastmodified":1566643451,
+    "wof:lastmodified":1582360597,
     "wof:name":"Mixco",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/171/681/421171681.geojson
+++ b/data/421/171/681/421171681.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008902,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54e8d4952fd151b1e2ed8488591c8dfe",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421171681,
-    "wof:lastmodified":1566643450,
+    "wof:lastmodified":1582360597,
     "wof:name":"Melchor De Mencos",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/171/683/421171683.geojson
+++ b/data/421/171/683/421171683.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2ae1e0f4d544dfa793411d221e9a7e7",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421171683,
-    "wof:lastmodified":1566643452,
+    "wof:lastmodified":1582360597,
     "wof:name":"Dolores",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/171/685/421171685.geojson
+++ b/data/421/171/685/421171685.geojson
@@ -239,6 +239,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae8a947e3df1c922e5549940a3a02393",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
         }
     ],
     "wof:id":421171685,
-    "wof:lastmodified":1566643451,
+    "wof:lastmodified":1582360597,
     "wof:name":"Quetzaltenango",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/171/687/421171687.geojson
+++ b/data/421/171/687/421171687.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e6fbf0672bf91837b7d299c342fc21c",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421171687,
-    "wof:lastmodified":1566643450,
+    "wof:lastmodified":1582360597,
     "wof:name":"Chichicastenango",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/171/689/421171689.geojson
+++ b/data/421/171/689/421171689.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bde2e2d113f66078d55fb379b37b6bcf",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421171689,
-    "wof:lastmodified":1566643450,
+    "wof:lastmodified":1582360597,
     "wof:name":"El Asintal",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/421/171/693/421171693.geojson
+++ b/data/421/171/693/421171693.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac20826ce565e9ab8ef41e843e16629a",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421171693,
-    "wof:lastmodified":1566643450,
+    "wof:lastmodified":1582360597,
     "wof:name":"Ciudad Vieja",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/171/697/421171697.geojson
+++ b/data/421/171/697/421171697.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"634c46f7206e430f0eb1f4a2088cada4",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421171697,
-    "wof:lastmodified":1566643452,
+    "wof:lastmodified":1582360597,
     "wof:name":"San Juan La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/171/915/421171915.geojson
+++ b/data/421/171/915/421171915.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008911,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0c8927ebe4a8a8a2730ffed845c835a",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421171915,
-    "wof:lastmodified":1566643451,
+    "wof:lastmodified":1582360597,
     "wof:name":"Zaragoza",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/172/213/421172213.geojson
+++ b/data/421/172/213/421172213.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008927,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0615f474803d7ab10be75aed804048eb",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421172213,
-    "wof:lastmodified":1566643410,
+    "wof:lastmodified":1582360594,
     "wof:name":"La Democracia",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/172/513/421172513.geojson
+++ b/data/421/172/513/421172513.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"88bef7acc20e3095e826d6e7ab2ffe6a",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421172513,
-    "wof:lastmodified":1566643410,
+    "wof:lastmodified":1582360594,
     "wof:name":"Chimaltenango",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/172/515/421172515.geojson
+++ b/data/421/172/515/421172515.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fcc211ea0f60e0f4a6eb1094fd910661",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421172515,
-    "wof:lastmodified":1566643411,
+    "wof:lastmodified":1582360594,
     "wof:name":"Santa Clara La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/172/617/421172617.geojson
+++ b/data/421/172/617/421172617.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"289c77b9e454e7fbc0ad7e055bed10a0",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421172617,
-    "wof:lastmodified":1566643408,
+    "wof:lastmodified":1582360594,
     "wof:name":"Rabinal",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/421/172/619/421172619.geojson
+++ b/data/421/172/619/421172619.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ef9679f78cb709c87f9ea4661f6b806",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421172619,
-    "wof:lastmodified":1566643409,
+    "wof:lastmodified":1582360594,
     "wof:name":"Tecpan Guatemala",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/172/621/421172621.geojson
+++ b/data/421/172/621/421172621.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d13cbf398d729a2207ff8cba1b96de97",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421172621,
-    "wof:lastmodified":1566643409,
+    "wof:lastmodified":1582360594,
     "wof:name":"San Vicente Pacaya",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/172/645/421172645.geojson
+++ b/data/421/172/645/421172645.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008950,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e730de22f3051c1c9f573d4246ece7bd",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421172645,
-    "wof:lastmodified":1566643409,
+    "wof:lastmodified":1582360594,
     "wof:name":"San Francisco El Alto",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/172/665/421172665.geojson
+++ b/data/421/172/665/421172665.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459008950,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1850a87449400645c4f34b33366022da",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421172665,
-    "wof:lastmodified":1566643410,
+    "wof:lastmodified":1582360594,
     "wof:name":"Colomba",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/173/721/421173721.geojson
+++ b/data/421/173/721/421173721.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009000,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bef09bb43d11f9189d0de82726af1c36",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421173721,
-    "wof:lastmodified":1566643406,
+    "wof:lastmodified":1582360593,
     "wof:name":"San Juan Atitan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/173/723/421173723.geojson
+++ b/data/421/173/723/421173723.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91f7cdd810fd42fc7144c5df62a76336",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421173723,
-    "wof:lastmodified":1566643405,
+    "wof:lastmodified":1582360593,
     "wof:name":"La Esperanza",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/175/387/421175387.geojson
+++ b/data/421/175/387/421175387.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e496a3eeb1969b5a056e7dd7dfb981f",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421175387,
-    "wof:lastmodified":1566643414,
+    "wof:lastmodified":1582360594,
     "wof:name":"Panajachel",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/175/573/421175573.geojson
+++ b/data/421/175/573/421175573.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009072,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfc5dbb8239e38ccbae8d4719abec4f0",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421175573,
-    "wof:lastmodified":1566643414,
+    "wof:lastmodified":1582360594,
     "wof:name":"Salama",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/421/175/579/421175579.geojson
+++ b/data/421/175/579/421175579.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009072,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f29eb480635bb4812f1c4825c19ae47",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421175579,
-    "wof:lastmodified":1566643414,
+    "wof:lastmodified":1582360594,
     "wof:name":"Comalapa",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/177/237/421177237.geojson
+++ b/data/421/177/237/421177237.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"574364fbe58444ff1f996e70105fff44",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421177237,
-    "wof:lastmodified":1566643436,
+    "wof:lastmodified":1582360596,
     "wof:name":"Pastores",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/177/381/421177381.geojson
+++ b/data/421/177/381/421177381.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009142,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2f88e19852d785a37a3142d98c1b81b",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421177381,
-    "wof:lastmodified":1566643436,
+    "wof:lastmodified":1582360596,
     "wof:name":"Jocotan",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/178/135/421178135.geojson
+++ b/data/421/178/135/421178135.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009171,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31ebe853deb8c42d77eab5884b4a02c6",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421178135,
-    "wof:lastmodified":1566643445,
+    "wof:lastmodified":1582360597,
     "wof:name":"Jacaltenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/178/323/421178323.geojson
+++ b/data/421/178/323/421178323.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009178,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aba108b7ced2340b9624074de675a2cb",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421178323,
-    "wof:lastmodified":1566643446,
+    "wof:lastmodified":1582360597,
     "wof:name":"Concepcion",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/178/903/421178903.geojson
+++ b/data/421/178/903/421178903.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009197,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d4ce17624b041138ac1ca5ace10db98",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421178903,
-    "wof:lastmodified":1566643446,
+    "wof:lastmodified":1582360597,
     "wof:name":"Patzun",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/178/905/421178905.geojson
+++ b/data/421/178/905/421178905.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009197,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"693578e44becffabbb1157cbc192d9cc",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421178905,
-    "wof:lastmodified":1566643446,
+    "wof:lastmodified":1582360597,
     "wof:name":"Petapa",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/178/907/421178907.geojson
+++ b/data/421/178/907/421178907.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009197,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f7f2bab4e2cb0572cfa299ddf6f1074",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421178907,
-    "wof:lastmodified":1566643445,
+    "wof:lastmodified":1582360597,
     "wof:name":"Guastatoya",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/421/178/909/421178909.geojson
+++ b/data/421/178/909/421178909.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009197,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e5790c9bb847300c5f25962348e66ad",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421178909,
-    "wof:lastmodified":1566643445,
+    "wof:lastmodified":1582360597,
     "wof:name":"Nueva Concepcion",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/179/171/421179171.geojson
+++ b/data/421/179/171/421179171.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009206,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d189a612cd6e783236da346ba58ccc8",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421179171,
-    "wof:lastmodified":1566643444,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Francisco",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/179/197/421179197.geojson
+++ b/data/421/179/197/421179197.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009207,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"02cad1d44ffb196c0bc6c1f1b9ec2dbb",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421179197,
-    "wof:lastmodified":1566643442,
+    "wof:lastmodified":1582360596,
     "wof:name":"Patzicia",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/181/909/421181909.geojson
+++ b/data/421/181/909/421181909.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009312,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b78c6d5cb234b80682996a71cb4ff978",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421181909,
-    "wof:lastmodified":1566643412,
+    "wof:lastmodified":1582360594,
     "wof:name":"San Juan Chamelco",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/182/335/421182335.geojson
+++ b/data/421/182/335/421182335.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009326,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f1c2be2b77cda4f78ca48d47fb26f70c",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421182335,
-    "wof:lastmodified":1566643447,
+    "wof:lastmodified":1582360597,
     "wof:name":"Lanquin",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/182/337/421182337.geojson
+++ b/data/421/182/337/421182337.geojson
@@ -216,6 +216,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009326,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e93815ddcc82aeedfdce0f539f7f2e4e",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":421182337,
-    "wof:lastmodified":1566643446,
+    "wof:lastmodified":1582360597,
     "wof:name":"Villa Nueva",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/182/433/421182433.geojson
+++ b/data/421/182/433/421182433.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009329,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6a2ca81acea59409a182302f5b5a91e",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421182433,
-    "wof:lastmodified":1566643448,
+    "wof:lastmodified":1582360597,
     "wof:name":"Rio Hondo",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/421/182/715/421182715.geojson
+++ b/data/421/182/715/421182715.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009339,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1954b484ef61a3ec68eddae89f9f6150",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421182715,
-    "wof:lastmodified":1566643447,
+    "wof:lastmodified":1582360597,
     "wof:name":"San Luis",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/182/831/421182831.geojson
+++ b/data/421/182/831/421182831.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009348,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"885b2886dd66c5ed61b70403e092ebab",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421182831,
-    "wof:lastmodified":1566643448,
+    "wof:lastmodified":1582360597,
     "wof:name":"Cahabon",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/182/885/421182885.geojson
+++ b/data/421/182/885/421182885.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eae57d9c12cae79591336245b6bbe5f9",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182885,
-    "wof:lastmodified":1566643448,
+    "wof:lastmodified":1582360597,
     "wof:name":"Santa Cruz Balanya",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/183/137/421183137.geojson
+++ b/data/421/183/137/421183137.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009359,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"531e18f42bf13a80ca2ead6c2d0be3b4",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421183137,
-    "wof:lastmodified":1566643437,
+    "wof:lastmodified":1582360596,
     "wof:name":"Jalapa",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/421/183/939/421183939.geojson
+++ b/data/421/183/939/421183939.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009395,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a0135b7c758a2a21f1309cbc626c185",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421183939,
-    "wof:lastmodified":1566643437,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Jose Chacaya",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/184/389/421184389.geojson
+++ b/data/421/184/389/421184389.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47a21eac347967ae7c609e15ebf176f3",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421184389,
-    "wof:lastmodified":1566643431,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Pedro Carcha",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/184/391/421184391.geojson
+++ b/data/421/184/391/421184391.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f477c3920b940b3f10e8f0a97fc46cc2",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421184391,
-    "wof:lastmodified":1566643430,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Cristobal Verapaz",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/184/393/421184393.geojson
+++ b/data/421/184/393/421184393.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8197a350075abb7490114897dc39585f",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421184393,
-    "wof:lastmodified":1566643431,
+    "wof:lastmodified":1582360596,
     "wof:name":"Malacatan",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/421/184/395/421184395.geojson
+++ b/data/421/184/395/421184395.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9863d16fd9dd5bd64b96a21085d73dc7",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421184395,
-    "wof:lastmodified":1566643431,
+    "wof:lastmodified":1582360596,
     "wof:name":"Canilla",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/184/397/421184397.geojson
+++ b/data/421/184/397/421184397.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c86deccbbd73bb033415115ac9c6c382",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421184397,
-    "wof:lastmodified":1566643430,
+    "wof:lastmodified":1582360596,
     "wof:name":"Nahuala",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/184/399/421184399.geojson
+++ b/data/421/184/399/421184399.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3899b6f198a658d78f9600bdb2ec5483",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421184399,
-    "wof:lastmodified":1566643430,
+    "wof:lastmodified":1582360596,
     "wof:name":"Santa Catarina Barahona",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/184/605/421184605.geojson
+++ b/data/421/184/605/421184605.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009416,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06c4bf3009f68fa07c39c90e45c4a465",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421184605,
-    "wof:lastmodified":1566643430,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Andres Xecul",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/184/713/421184713.geojson
+++ b/data/421/184/713/421184713.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009419,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97358c7b38343a49ddc0eee5fa1c8793",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421184713,
-    "wof:lastmodified":1566643430,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Agustin Acasaguastlan",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/421/184/715/421184715.geojson
+++ b/data/421/184/715/421184715.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009420,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65bc2f76fdce0384ecc720bb183c92e7",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421184715,
-    "wof:lastmodified":1566643431,
+    "wof:lastmodified":1582360596,
     "wof:name":"Santa Lucia Cotzumalguapa",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/184/717/421184717.geojson
+++ b/data/421/184/717/421184717.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009420,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cee5c1674fd0f1d868c86d7ea479162d",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421184717,
-    "wof:lastmodified":1566643432,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Raymundo",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/184/719/421184719.geojson
+++ b/data/421/184/719/421184719.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009420,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"777a7738f7658908a60ec586524936ec",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421184719,
-    "wof:lastmodified":1566643431,
+    "wof:lastmodified":1582360596,
     "wof:name":"Morales",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/421/184/975/421184975.geojson
+++ b/data/421/184/975/421184975.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009428,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14d37d912f7f4cb0c1f1d21d41e3929b",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421184975,
-    "wof:lastmodified":1566643432,
+    "wof:lastmodified":1582360596,
     "wof:name":"San Cristobal Totonicapan",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/185/525/421185525.geojson
+++ b/data/421/185/525/421185525.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009446,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e0808b8bbc7bec5b64ac36a60aee8a2",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421185525,
-    "wof:lastmodified":1566643453,
+    "wof:lastmodified":1582360598,
     "wof:name":"Ipala",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/185/527/421185527.geojson
+++ b/data/421/185/527/421185527.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009446,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c4cacd299d71c8fcec6e1650b0c6d0b",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421185527,
-    "wof:lastmodified":1566643453,
+    "wof:lastmodified":1582360598,
     "wof:name":"Concepcion La Minas",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/185/569/421185569.geojson
+++ b/data/421/185/569/421185569.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009447,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59f4beee327f87926b77f23a73956fcc",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":421185569,
-    "wof:lastmodified":1566643452,
+    "wof:lastmodified":1582360597,
     "wof:name":"Barillas",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/185/571/421185571.geojson
+++ b/data/421/185/571/421185571.geojson
@@ -165,6 +165,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009447,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74beec5d2a19909150d8db21f36525e7",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":421185571,
-    "wof:lastmodified":1566643453,
+    "wof:lastmodified":1582360598,
     "wof:name":"La Libertad",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/185/575/421185575.geojson
+++ b/data/421/185/575/421185575.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009447,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67a40fab60c1c895c37970fd770ada9f",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421185575,
-    "wof:lastmodified":1566643452,
+    "wof:lastmodified":1582360597,
     "wof:name":"Santiago Chimaltenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/185/999/421185999.geojson
+++ b/data/421/185/999/421185999.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009461,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"483054b20fabd83c61a8d46002a92da1",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421185999,
-    "wof:lastmodified":1566643452,
+    "wof:lastmodified":1582360597,
     "wof:name":"Fraijanes",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/186/001/421186001.geojson
+++ b/data/421/186/001/421186001.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009461,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0146b6e2e38773595d522edcb9a9cf27",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421186001,
-    "wof:lastmodified":1566643411,
+    "wof:lastmodified":1582360594,
     "wof:name":"Joyabaj",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/186/319/421186319.geojson
+++ b/data/421/186/319/421186319.geojson
@@ -173,6 +173,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009477,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"70bbea72430aaee3e482ff3a7e159080",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":421186319,
-    "wof:lastmodified":1566643412,
+    "wof:lastmodified":1582360594,
     "wof:name":"Huehuetenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/186/589/421186589.geojson
+++ b/data/421/186/589/421186589.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009485,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e34ca3448665974c84f85a1265591f4",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421186589,
-    "wof:lastmodified":1566643411,
+    "wof:lastmodified":1582360594,
     "wof:name":"Santo Tom\u00e1s Chichicastenango",
     "wof:parent_id":421171687,
     "wof:placetype":"locality",

--- a/data/421/187/937/421187937.geojson
+++ b/data/421/187/937/421187937.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1afdcf7bb80e6331c92242008b5ba7f0",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421187937,
-    "wof:lastmodified":1566643402,
+    "wof:lastmodified":1582360593,
     "wof:name":"Acatenango",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/187/939/421187939.geojson
+++ b/data/421/187/939/421187939.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4309edb991405d90e9460a14b776fe7",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421187939,
-    "wof:lastmodified":1566643402,
+    "wof:lastmodified":1582360593,
     "wof:name":"Sayaxche",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/188/729/421188729.geojson
+++ b/data/421/188/729/421188729.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009576,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47d6f85f6a41336453e7f7ed163c5a75",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421188729,
-    "wof:lastmodified":1566643408,
+    "wof:lastmodified":1582360594,
     "wof:name":"Esquipulas",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/188/895/421188895.geojson
+++ b/data/421/188/895/421188895.geojson
@@ -282,6 +282,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009587,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b0bd636f231228821dab634d6ab3bb9",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         }
     ],
     "wof:id":421188895,
-    "wof:lastmodified":1566643407,
+    "wof:lastmodified":1582360594,
     "wof:name":"Chahal",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/188/897/421188897.geojson
+++ b/data/421/188/897/421188897.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009587,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1335624af99b34941edd6e0657b4a7da",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421188897,
-    "wof:lastmodified":1566643407,
+    "wof:lastmodified":1582360594,
     "wof:name":"San Andres Iztapa",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/188/899/421188899.geojson
+++ b/data/421/188/899/421188899.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009587,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1fdfd83619a1c94da1fa9134e86d981d",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421188899,
-    "wof:lastmodified":1566643407,
+    "wof:lastmodified":1582360594,
     "wof:name":"San Lucas Sacatepequez",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/189/121/421189121.geojson
+++ b/data/421/189/121/421189121.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33e0382e71b40608e392fe94f136a3d9",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421189121,
-    "wof:lastmodified":1566643407,
+    "wof:lastmodified":1582360594,
     "wof:name":"Santa Maria De Jesus",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/189/123/421189123.geojson
+++ b/data/421/189/123/421189123.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b78487205a03b8914d8b576851da979",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421189123,
-    "wof:lastmodified":1566643407,
+    "wof:lastmodified":1582360594,
     "wof:name":"Santa Catarina Palopo",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/189/125/421189125.geojson
+++ b/data/421/189/125/421189125.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37ddabee119ebc0d7160c62f2130c546",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421189125,
-    "wof:lastmodified":1566643407,
+    "wof:lastmodified":1582360594,
     "wof:name":"San Antonio Palopo",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/189/489/421189489.geojson
+++ b/data/421/189/489/421189489.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009626,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea21ca4eda35e6763f56492bde37c87f",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421189489,
-    "wof:lastmodified":1566643407,
+    "wof:lastmodified":1582360594,
     "wof:name":"San Juan Ixcoy",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/189/491/421189491.geojson
+++ b/data/421/189/491/421189491.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009626,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c324d6471e051e32de994925a290511",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":421189491,
-    "wof:lastmodified":1566643406,
+    "wof:lastmodified":1582360593,
     "wof:name":"Jutiapa",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/421/190/247/421190247.geojson
+++ b/data/421/190/247/421190247.geojson
@@ -255,6 +255,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009652,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"832a32d69e5621c672382d36cf57c72c",
     "wof:hierarchy":[
         {
@@ -265,7 +268,7 @@
         }
     ],
     "wof:id":421190247,
-    "wof:lastmodified":1566643420,
+    "wof:lastmodified":1582360595,
     "wof:name":"Coban",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/190/249/421190249.geojson
+++ b/data/421/190/249/421190249.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009652,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"580c15ba3141e536ada92646138881ab",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421190249,
-    "wof:lastmodified":1566643421,
+    "wof:lastmodified":1582360595,
     "wof:name":"Santa Cruz La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/190/493/421190493.geojson
+++ b/data/421/190/493/421190493.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009659,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82dc637f5bd825e5b13516b48c34b34f",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421190493,
-    "wof:lastmodified":1566643421,
+    "wof:lastmodified":1582360595,
     "wof:name":"Todos Santos Cuchumatan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/190/497/421190497.geojson
+++ b/data/421/190/497/421190497.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009659,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c709a3379c450af0334814337d4e8ace",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421190497,
-    "wof:lastmodified":1566643420,
+    "wof:lastmodified":1582360595,
     "wof:name":"Alotenango",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/190/499/421190499.geojson
+++ b/data/421/190/499/421190499.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009659,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a70d699e1e43a04dfadb434c341589e9",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421190499,
-    "wof:lastmodified":1566643420,
+    "wof:lastmodified":1582360595,
     "wof:name":"San Marcos",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/421/190/501/421190501.geojson
+++ b/data/421/190/501/421190501.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009659,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7846025d18b375252e0a0ac1f6dfca5",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421190501,
-    "wof:lastmodified":1566643420,
+    "wof:lastmodified":1582360595,
     "wof:name":"Taxisco",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/421/190/503/421190503.geojson
+++ b/data/421/190/503/421190503.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009659,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45aca3d13587aa9fe0126a98bbfd6e40",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421190503,
-    "wof:lastmodified":1566643419,
+    "wof:lastmodified":1582360595,
     "wof:name":"Solola",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/190/509/421190509.geojson
+++ b/data/421/190/509/421190509.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009660,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c083642ea6d182dcf82e76700b6e9f4",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421190509,
-    "wof:lastmodified":1566643420,
+    "wof:lastmodified":1582360595,
     "wof:name":"San Lucas Toliman",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/191/199/421191199.geojson
+++ b/data/421/191/199/421191199.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e1f0624ea93d9009903a96c1e66df87",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421191199,
-    "wof:lastmodified":1566643418,
+    "wof:lastmodified":1582360595,
     "wof:name":"San Martin Jilotepeque",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/191/201/421191201.geojson
+++ b/data/421/191/201/421191201.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1522a938e2024cffcbf478da2b8cfd0b",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421191201,
-    "wof:lastmodified":1566643418,
+    "wof:lastmodified":1582360595,
     "wof:name":"Cuilapa",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/421/191/319/421191319.geojson
+++ b/data/421/191/319/421191319.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009688,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f77aed579ac5a3e6b9dfd6c05cff12dc",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191319,
-    "wof:lastmodified":1566643419,
+    "wof:lastmodified":1582360595,
     "wof:name":"San Gabriel",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/421/191/321/421191321.geojson
+++ b/data/421/191/321/421191321.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009688,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6affcc63c3f484b0b561ec09ab661b70",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421191321,
-    "wof:lastmodified":1566643419,
+    "wof:lastmodified":1582360595,
     "wof:name":"Santa Maria Chiquimula",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/191/461/421191461.geojson
+++ b/data/421/191/461/421191461.geojson
@@ -653,6 +653,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009693,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0aeb93f4fa40ea3030f55c77a2ea0c14",
     "wof:hierarchy":[
         {
@@ -663,7 +666,7 @@
         }
     ],
     "wof:id":421191461,
-    "wof:lastmodified":1566643419,
+    "wof:lastmodified":1582360595,
     "wof:name":"Guatemala",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/191/463/421191463.geojson
+++ b/data/421/191/463/421191463.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009693,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e03d56ed3279a40c8fe0f2f079c0e3a2",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421191463,
-    "wof:lastmodified":1566643418,
+    "wof:lastmodified":1582360595,
     "wof:name":"Malacatancito",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/191/465/421191465.geojson
+++ b/data/421/191/465/421191465.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009693,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22ee9f4b6ae3ad2f0b84d971bd2df218",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191465,
-    "wof:lastmodified":1566643418,
+    "wof:lastmodified":1582360595,
     "wof:name":"Mataquescuintla",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/421/191/467/421191467.geojson
+++ b/data/421/191/467/421191467.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009693,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2dab0cde66ed876ec80d34e56cdb3bbe",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421191467,
-    "wof:lastmodified":1566643418,
+    "wof:lastmodified":1582360595,
     "wof:name":"Sumpango",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/194/695/421194695.geojson
+++ b/data/421/194/695/421194695.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009816,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a553e920fa5a0c3f8e51d51db59ccd7",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421194695,
-    "wof:lastmodified":1566643388,
+    "wof:lastmodified":1582360592,
     "wof:name":"El Estor",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/421/195/013/421195013.geojson
+++ b/data/421/195/013/421195013.geojson
@@ -285,6 +285,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c60fcc202e329072f8105c8b00cd92f1",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         }
     ],
     "wof:id":421195013,
-    "wof:lastmodified":1566643387,
+    "wof:lastmodified":1582360592,
     "wof:name":"Cantel",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/195/541/421195541.geojson
+++ b/data/421/195/541/421195541.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009851,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ecf83f9d0480de666d6e75a7c27fd26",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421195541,
-    "wof:lastmodified":1566643387,
+    "wof:lastmodified":1582360592,
     "wof:name":"Santa Lucia La Reforma",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/195/543/421195543.geojson
+++ b/data/421/195/543/421195543.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009851,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfc78b54a185a86ed5b801b98f377646",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421195543,
-    "wof:lastmodified":1566643387,
+    "wof:lastmodified":1582360592,
     "wof:name":"Nueva Santa Rosa",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/421/195/547/421195547.geojson
+++ b/data/421/195/547/421195547.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009851,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db049c8e5668916863c044f38eaa1b75",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421195547,
-    "wof:lastmodified":1566643387,
+    "wof:lastmodified":1582360592,
     "wof:name":"San Antonio Sacatepequez",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/421/196/435/421196435.geojson
+++ b/data/421/196/435/421196435.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009881,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"960b613c39f25bcb1530f60d2652a8b8",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421196435,
-    "wof:lastmodified":1566643417,
+    "wof:lastmodified":1582360594,
     "wof:name":"Los Amates",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/421/196/545/421196545.geojson
+++ b/data/421/196/545/421196545.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b24d7a55bcdac91f5ca46d459dc344f3",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421196545,
-    "wof:lastmodified":1566643417,
+    "wof:lastmodified":1582360594,
     "wof:name":"Uspantan",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/196/547/421196547.geojson
+++ b/data/421/196/547/421196547.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c64cd0c92bcb76a936461d76a2bb44a1",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421196547,
-    "wof:lastmodified":1566643417,
+    "wof:lastmodified":1582360595,
     "wof:name":"Chicacao",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/421/196/995/421196995.geojson
+++ b/data/421/196/995/421196995.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60deb423dd3ce3eae996eca5b623543e",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421196995,
-    "wof:lastmodified":1566643417,
+    "wof:lastmodified":1582360594,
     "wof:name":"Patzite",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/197/631/421197631.geojson
+++ b/data/421/197/631/421197631.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009920,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd4d06a8eca02415e1627de5a3d9a226",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421197631,
-    "wof:lastmodified":1566643423,
+    "wof:lastmodified":1582360595,
     "wof:name":"Colotenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/198/237/421198237.geojson
+++ b/data/421/198/237/421198237.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459009941,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"79c6b4f3ca204cae8c4c7748e065ed5a",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421198237,
-    "wof:lastmodified":1566643416,
+    "wof:lastmodified":1582360594,
     "wof:name":"San Pedro Pinula",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/421/200/683/421200683.geojson
+++ b/data/421/200/683/421200683.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010034,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d17933ca7522f8081a373d3e04382a27",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421200683,
-    "wof:lastmodified":1566643425,
+    "wof:lastmodified":1582360595,
     "wof:name":"Salcaja",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/200/685/421200685.geojson
+++ b/data/421/200/685/421200685.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010035,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17d46b831cb8aa55e9331a70c5e4b842",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421200685,
-    "wof:lastmodified":1566643425,
+    "wof:lastmodified":1582360595,
     "wof:name":"San Juan Cotzal",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/200/731/421200731.geojson
+++ b/data/421/200/731/421200731.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010036,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7a12d3e788d9c6a9949bafd954228c9",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421200731,
-    "wof:lastmodified":1566643425,
+    "wof:lastmodified":1582360595,
     "wof:name":"San Benito",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/201/163/421201163.geojson
+++ b/data/421/201/163/421201163.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010058,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"18bec6cbf98a720cbbedb04a42958ea3",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421201163,
-    "wof:lastmodified":1566643428,
+    "wof:lastmodified":1582360595,
     "wof:name":"San Sebastian Huehuetenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/201/585/421201585.geojson
+++ b/data/421/201/585/421201585.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010077,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf842b7db93e72efc1ad165f61ba35a6",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421201585,
-    "wof:lastmodified":1566643429,
+    "wof:lastmodified":1582360596,
     "wof:name":"Palin",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/201/591/421201591.geojson
+++ b/data/421/201/591/421201591.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010077,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49bd9d4ca9aa52b8ad84044d5b1597c9",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421201591,
-    "wof:lastmodified":1566643428,
+    "wof:lastmodified":1582360595,
     "wof:name":"Chinautla",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/201/597/421201597.geojson
+++ b/data/421/201/597/421201597.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010077,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da24935fac6411ec19a010d277c4406b",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421201597,
-    "wof:lastmodified":1566643428,
+    "wof:lastmodified":1582360595,
     "wof:name":"Santa Cruz Del Quiche",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/201/599/421201599.geojson
+++ b/data/421/201/599/421201599.geojson
@@ -269,6 +269,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010077,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c81e0b55416147442ba0c5a0f761908",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         }
     ],
     "wof:id":421201599,
-    "wof:lastmodified":1566643427,
+    "wof:lastmodified":1582360595,
     "wof:name":"Antigua Guatemala",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/201/709/421201709.geojson
+++ b/data/421/201/709/421201709.geojson
@@ -195,7 +195,8 @@
     "qs:woe_id":82730,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "src:population":"quattroshapes",
     "wof:belongsto":[
@@ -217,6 +218,10 @@
     },
     "wof:country":"GT",
     "wof:created":1459010081,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"895a5b5243f5f03f9e3b7960ac1d69d2",
     "wof:hierarchy":[
         {
@@ -228,7 +233,7 @@
         }
     ],
     "wof:id":421201709,
-    "wof:lastmodified":1566643426,
+    "wof:lastmodified":1582360595,
     "wof:name":"El Progreso",
     "wof:parent_id":421178907,
     "wof:placetype":"locality",

--- a/data/421/202/273/421202273.geojson
+++ b/data/421/202/273/421202273.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010111,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc54191b511168ccb81ef3e45b1dcd36",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421202273,
-    "wof:lastmodified":1566643397,
+    "wof:lastmodified":1582360593,
     "wof:name":"Santa Ana",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/202/281/421202281.geojson
+++ b/data/421/202/281/421202281.geojson
@@ -279,6 +279,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010111,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3148cf433fb6add5388d286c1d2c9cb",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         }
     ],
     "wof:id":421202281,
-    "wof:lastmodified":1566643398,
+    "wof:lastmodified":1582360593,
     "wof:name":"San Jose",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/203/203/421203203.geojson
+++ b/data/421/203/203/421203203.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010143,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7d7c6ecf360724abf107ed7016212de",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421203203,
-    "wof:lastmodified":1566643396,
+    "wof:lastmodified":1582360593,
     "wof:name":"Champerico",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/421/203/223/421203223.geojson
+++ b/data/421/203/223/421203223.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f748cb7de7260b823df54074e9f6d50d",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421203223,
-    "wof:lastmodified":1566643396,
+    "wof:lastmodified":1582360593,
     "wof:name":"Pochuta",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/203/225/421203225.geojson
+++ b/data/421/203/225/421203225.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6f694b6aca41fcc5d6b4793a3d24a19",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421203225,
-    "wof:lastmodified":1566643396,
+    "wof:lastmodified":1582360593,
     "wof:name":"Poptun",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/203/475/421203475.geojson
+++ b/data/421/203/475/421203475.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010153,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bc0b65dd77988ca74cde6bacae86a8d",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421203475,
-    "wof:lastmodified":1566643396,
+    "wof:lastmodified":1582360593,
     "wof:name":"Purula",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/421/203/515/421203515.geojson
+++ b/data/421/203/515/421203515.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010155,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"807f640f9ac1115f9e0c6b41b9a45c65",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421203515,
-    "wof:lastmodified":1566643397,
+    "wof:lastmodified":1582360593,
     "wof:name":"San Miguel Duenas",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/203/587/421203587.geojson
+++ b/data/421/203/587/421203587.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2abef6e46a1a2c084944b2799edb708",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421203587,
-    "wof:lastmodified":1566643396,
+    "wof:lastmodified":1582360593,
     "wof:name":"Chiquimulilla",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/421/203/667/421203667.geojson
+++ b/data/421/203/667/421203667.geojson
@@ -266,6 +266,7 @@
     "qs:woe_id":83017,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "wd:latitude":14.297778,
@@ -287,6 +288,10 @@
     },
     "wof:country":"GT",
     "wof:created":1459010159,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd3f4ddf610e5def4c14ccccd6bdaae2",
     "wof:hierarchy":[
         {
@@ -298,7 +303,7 @@
         }
     ],
     "wof:id":421203667,
-    "wof:lastmodified":1561844755,
+    "wof:lastmodified":1582360593,
     "wof:name":"Escuintla",
     "wof:parent_id":421168071,
     "wof:placetype":"locality",

--- a/data/421/204/021/421204021.geojson
+++ b/data/421/204/021/421204021.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010171,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d63cb4df07d4c4e0d06cdea36d546740",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":421204021,
-    "wof:lastmodified":1566643395,
+    "wof:lastmodified":1582360593,
     "wof:name":"Chiquimula",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/204/285/421204285.geojson
+++ b/data/421/204/285/421204285.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010179,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f06ec5418a1185f9fe59e4d80c3e114",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421204285,
-    "wof:lastmodified":1566643395,
+    "wof:lastmodified":1582360593,
     "wof:name":"Cunen",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/204/387/421204387.geojson
+++ b/data/421/204/387/421204387.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010184,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71bd760903105faf58c706e004161ba5",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421204387,
-    "wof:lastmodified":1566643395,
+    "wof:lastmodified":1582360593,
     "wof:name":"Retalhuleu",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/421/204/557/421204557.geojson
+++ b/data/421/204/557/421204557.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010190,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4bbe190f7116b8c6e206947e07ea8562",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421204557,
-    "wof:lastmodified":1566643394,
+    "wof:lastmodified":1582360593,
     "wof:name":"Chisec",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/204/771/421204771.geojson
+++ b/data/421/204/771/421204771.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010197,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"736d1102c97fcca430b176dd3843e632",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421204771,
-    "wof:lastmodified":1566643395,
+    "wof:lastmodified":1582360593,
     "wof:name":"Totonicapan",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/205/243/421205243.geojson
+++ b/data/421/205/243/421205243.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"GT",
     "wof:created":1459010216,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c4a31e2d29667266a1ba6cdf4966d6c0",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421205243,
-    "wof:lastmodified":1566643399,
+    "wof:lastmodified":1582360593,
     "wof:name":"San Juan Ermita",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/856/323/85/85632385.geojson
+++ b/data/856/323/85/85632385.geojson
@@ -907,7 +907,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -983,7 +982,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1582360580,
+    "wof:lastmodified":1583241940,
     "wof:name":"Guatemala",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/323/85/85632385.geojson
+++ b/data/856/323/85/85632385.geojson
@@ -906,8 +906,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -962,6 +963,11 @@
     },
     "wof:country":"GT",
     "wof:country_alpha3":"GTM",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"7cba542d9c31ba2edc7bd5651fcd8804",
     "wof:hierarchy":[
         {
@@ -977,7 +983,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642750,
+    "wof:lastmodified":1582360580,
     "wof:name":"Guatemala",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/716/35/85671635.geojson
+++ b/data/856/716/35/85671635.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Baja Verapaz Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e91d86451d5fd914018c6d379176ac5f",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642753,
+    "wof:lastmodified":1582360582,
     "wof:name":"Baja Verapaz",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/41/85671641.geojson
+++ b/data/856/716/41/85671641.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Huehuetenango Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4786d5c91e52fc9cc6affacaea4dad63",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642754,
+    "wof:lastmodified":1582360582,
     "wof:name":"Huehuetenango",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/47/85671647.geojson
+++ b/data/856/716/47/85671647.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Pet\u00e9n Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b6d0fd8273dfd3038f640be402efab0",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642755,
+    "wof:lastmodified":1582360583,
     "wof:name":"Pet\u00e9n",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/51/85671651.geojson
+++ b/data/856/716/51/85671651.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Quetzaltenango Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad81ed17ad0450a938283c460ee869bf",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642753,
+    "wof:lastmodified":1582360582,
     "wof:name":"Quezaltenango",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/59/85671659.geojson
+++ b/data/856/716/59/85671659.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Retalhuleu"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b9d96ab84e3f898929ab419b359ae1c",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642753,
+    "wof:lastmodified":1582360582,
     "wof:name":"Retalhuleu",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/61/85671661.geojson
+++ b/data/856/716/61/85671661.geojson
@@ -302,6 +302,9 @@
         "wk:page":"San Marcos Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2871269803a597ffd762aafacd121695",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642752,
+    "wof:lastmodified":1582360582,
     "wof:name":"San Marcos",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/65/85671665.geojson
+++ b/data/856/716/65/85671665.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Alta Verapaz Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55b3111dbe56ee32d2dd25b0bcd17d28",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642754,
+    "wof:lastmodified":1582360582,
     "wof:name":"Alta Verapaz",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/71/85671671.geojson
+++ b/data/856/716/71/85671671.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Chimaltenango Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68ebbba326a2c0817485e89a546446e3",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642755,
+    "wof:lastmodified":1582360583,
     "wof:name":"Chimaltenango",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/77/85671677.geojson
+++ b/data/856/716/77/85671677.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Escuintla Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9a14fdf9f97f5389af6180b01650797",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642755,
+    "wof:lastmodified":1582360582,
     "wof:name":"Escuintla",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/81/85671681.geojson
+++ b/data/856/716/81/85671681.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Guatemala Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"989a617549776c58eb565e027741f712",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642753,
+    "wof:lastmodified":1582360582,
     "wof:name":"Guatemala",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/83/85671683.geojson
+++ b/data/856/716/83/85671683.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Suchitep\u00e9quez Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f62caceb9443c09fcadd2c58c4dd875f",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642754,
+    "wof:lastmodified":1582360582,
     "wof:name":"Suchitep\u00e9quez",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/87/85671687.geojson
+++ b/data/856/716/87/85671687.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Sacatep\u00e9quez Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31005278470f7ee62141095b86c794c4",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642753,
+    "wof:lastmodified":1582360582,
     "wof:name":"Sacatepequez",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/95/85671695.geojson
+++ b/data/856/716/95/85671695.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Solol\u00e1 Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17abb31c81731084780201011f07ab90",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642753,
+    "wof:lastmodified":1582360582,
     "wof:name":"Solol\u00e1",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/97/85671697.geojson
+++ b/data/856/716/97/85671697.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Totonicap\u00e1n Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea0f5815b24b23829cec993a7dd2601a",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642754,
+    "wof:lastmodified":1582360582,
     "wof:name":"Totonicap\u00e1n",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/01/85671701.geojson
+++ b/data/856/717/01/85671701.geojson
@@ -295,6 +295,9 @@
         "wk:page":"El Progreso Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d898f2dc4062829b80d96965b9f41c9c",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642752,
+    "wof:lastmodified":1582360581,
     "wof:name":"El Progreso",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/05/85671705.geojson
+++ b/data/856/717/05/85671705.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Santa Rosa Department, Guatemala"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07c73ed1dadd914d9a3bc0ec7b37e58e",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642751,
+    "wof:lastmodified":1582360581,
     "wof:name":"Santa Rosa",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/09/85671709.geojson
+++ b/data/856/717/09/85671709.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Izabal Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b6fdbd3ccad87d4102898f60fde6e7a",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642752,
+    "wof:lastmodified":1582360581,
     "wof:name":"Izabal",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/15/85671715.geojson
+++ b/data/856/717/15/85671715.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Chiquimula Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2da7d6c66191f350be667d0475bdbed2",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642752,
+    "wof:lastmodified":1582360582,
     "wof:name":"Chiquimula",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/19/85671719.geojson
+++ b/data/856/717/19/85671719.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Jalapa Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b37b51e206ff93e0f4d1137300e6ce4",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642752,
+    "wof:lastmodified":1582360581,
     "wof:name":"Jalapa",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/23/85671723.geojson
+++ b/data/856/717/23/85671723.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Jutiapa Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2b3a4d5c5c7023b21d2092dde6b97c6",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642752,
+    "wof:lastmodified":1582360581,
     "wof:name":"Jutiapa",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/27/85671727.geojson
+++ b/data/856/717/27/85671727.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Zacapa Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53f3bb9a9f1f9cceaf38bc2b458ba0a3",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642751,
+    "wof:lastmodified":1582360581,
     "wof:name":"Zacapa",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/33/85671733.geojson
+++ b/data/856/717/33/85671733.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Quich\u00e9 Department"
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fca4790ea69c4fdd050538055002742d",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1566642751,
+    "wof:lastmodified":1582360581,
     "wof:name":"Quich\u00e9",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/857/938/63/85793863.geojson
+++ b/data/857/938/63/85793863.geojson
@@ -135,6 +135,9 @@
         "qs_pg:id":489144
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9fb159db9e906c058defb567391c092d",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566642750,
+    "wof:lastmodified":1582360580,
     "wof:name":"Atl\u00e1ntida",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/65/85793865.geojson
+++ b/data/857/938/65/85793865.geojson
@@ -75,6 +75,9 @@
         "qs:id":1082609
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45cf94a18ddaab80b2697ebfb2bf1923",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379333,
+    "wof:lastmodified":1582360580,
     "wof:name":"Garibaldi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/69/85793869.geojson
+++ b/data/857/938/69/85793869.geojson
@@ -76,6 +76,9 @@
         "qs:id":211073
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d6cc7f1fb4415c90d1a899a9e049f24",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379333,
+    "wof:lastmodified":1582360580,
     "wof:name":"Las Victorias",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/851/61/85885161.geojson
+++ b/data/858/851/61/85885161.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":1137772
     },
     "wof:country":"GT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5ca844fa11b2064f9dea052f6536e24",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566642755,
+    "wof:lastmodified":1582360583,
     "wof:name":"Salomon Gonzalez Blanco",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.