### PR TITLE
Name updates

### DIFF
--- a/data/856/323/85/85632385.geojson
+++ b/data/856/323/85/85632385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.191534,
-    "geom:area_square_m":109397740596.740585,
+    "geom:area_square_m":109397739413.181458,
     "geom:bbox":"-92.231153,13.740028,-88.231057,17.815687",
     "geom:latitude":15.697019,
     "geom:longitude":-90.357506,
@@ -57,6 +57,9 @@
     ],
     "name:arg_x_preferred":[
         "Guatemala"
+    ],
+    "name:ary_x_preferred":[
+        "\u06ad\u0648\u0627\u0637\u064a\u0645\u0627\u0644\u0627"
     ],
     "name:arz_x_preferred":[
         "\u062c\u0648\u0627\u062a\u064a\u0645\u0627\u0644\u0627"
@@ -141,6 +144,9 @@
     "name:che_x_preferred":[
         "\u0413\u0432\u0430\u0442\u0435\u043c\u0430\u043b\u0430"
     ],
+    "name:chy_x_preferred":[
+        "Guatemala"
+    ],
     "name:ckb_x_preferred":[
         "\u06af\u0648\u0627\u062a\u06cc\u0645\u0627\u0644\u0627"
     ],
@@ -157,6 +163,12 @@
         "Guatemala"
     ],
     "name:dan_x_preferred":[
+        "Guatemala"
+    ],
+    "name:deu_at_x_preferred":[
+        "Guatemala"
+    ],
+    "name:deu_ch_x_preferred":[
         "Guatemala"
     ],
     "name:deu_x_preferred":[
@@ -176,6 +188,12 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03bf\u03c5\u03b1\u03c4\u03b5\u03bc\u03ac\u03bb\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Guatemala"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Guatemala"
     ],
     "name:eng_x_preferred":[
         "Guatemala"
@@ -237,6 +255,9 @@
     ],
     "name:gag_x_preferred":[
         "Gvatemala"
+    ],
+    "name:gcr_x_preferred":[
+        "Gwat\u00e9mala"
     ],
     "name:ger_x_variant":[
         "Republik Guatemala"
@@ -481,6 +502,9 @@
     "name:mon_x_preferred":[
         "\u0413\u0432\u0430\u0442\u0435\u043c\u0430\u043b"
     ],
+    "name:mri_x_preferred":[
+        "Kuatam\u0101ra"
+    ],
     "name:mrj_x_preferred":[
         "\u0413\u0432\u0430\u0442\u0435\u043c\u0430\u043b\u0430"
     ],
@@ -581,6 +605,9 @@
     "name:pol_x_preferred":[
         "Gwatemala"
     ],
+    "name:por_br_x_preferred":[
+        "Guatemala"
+    ],
     "name:por_x_preferred":[
         "Guatemala"
     ],
@@ -624,6 +651,9 @@
     "name:san_x_preferred":[
         "\u0917\u094d\u0935\u093e\u091f\u0947\u092e\u093e\u0932\u093e"
     ],
+    "name:sat_x_preferred":[
+        "\u1c5c\u1c63\u1c69\u1c74\u1c6e\u1c62\u1c5f\u1c5e\u1c5f"
+    ],
     "name:scn_x_preferred":[
         "Guatemala"
     ],
@@ -654,6 +684,9 @@
     "name:sna_x_preferred":[
         "Guatemala"
     ],
+    "name:snd_x_preferred":[
+        "\u06af\u0648\u0626\u067d\u064a \u0645\u0627\u0644\u0627"
+    ],
     "name:som_x_preferred":[
         "Guatemala"
     ],
@@ -672,11 +705,23 @@
     "name:sqi_x_variant":[
         "Guatemal\u00eb"
     ],
+    "name:srd_x_preferred":[
+        "Guatemala"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0413\u0432\u0430\u0442\u0435\u043c\u0430\u043b\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Gvatemala"
+    ],
     "name:srp_x_preferred":[
         "\u0413\u0432\u0430\u0442\u0435\u043c\u0430\u043b\u0430"
     ],
     "name:ssw_x_preferred":[
         "IGwathamala"
+    ],
+    "name:stq_x_preferred":[
+        "Guatemala"
     ],
     "name:sun_x_preferred":[
         "Guat\u00e9mala"
@@ -692,6 +737,9 @@
     ],
     "name:szl_x_preferred":[
         "Gwatymala"
+    ],
+    "name:szy_x_preferred":[
+        "Guatemala"
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bc1\u0bb5\u0bbe\u0ba4\u0bcd\u0ba4\u0bae\u0bbe\u0bb2\u0bbe"
@@ -738,6 +786,9 @@
     ],
     "name:tur_x_preferred":[
         "Guatemala"
+    ],
+    "name:udm_x_preferred":[
+        "\u0413\u0432\u0430\u0442\u0435\u043c\u0430\u043b\u0430"
     ],
     "name:uig_x_preferred":[
         "\u06af\u06cb\u0627\u062a\u06d0\u0645\u0627\u0644\u0627"
@@ -814,8 +865,26 @@
     "name:zha_x_preferred":[
         "Guatemala"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5371\u5730\u9a6c\u62c9"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5371\u5730\u99ac\u62c9"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Guatemala"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u74dc\u5730\u99ac\u62c9"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u5371\u5730\u9a6c\u62c9"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5371\u5730\u9a6c\u62c9"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u74dc\u5730\u99ac\u62c9"
     ],
     "name:zho_x_preferred":[
         "\u5371\u5730\u9a6c\u62c9"
@@ -983,7 +1052,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1583797346,
+    "wof:lastmodified":1587427371,
     "wof:name":"Guatemala",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.