### PR TITLE
gt concordances, placetype local, and more

### DIFF
--- a/data/110/869/525/5/1108695255.geojson
+++ b/data/110/869/525/5/1108695255.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"GT.JU.AB",
         "wd:id":"Q2403493"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493561,
     "wof:geomhash":"52527245363179dcb737923e6abaed00",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108695255,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"Agua Blanca",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/525/7/1108695257.geojson
+++ b/data/110/869/525/7/1108695257.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GT.HU.AG",
         "wd:id":"Q2402581"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493563,
     "wof:geomhash":"9fcc745fb80f9e175770365a9b96aaf9",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108695257,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"Aguacatan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/525/9/1108695259.geojson
+++ b/data/110/869/525/9/1108695259.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GT.QZ.AL",
         "wd:id":"Q284830"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493565,
     "wof:geomhash":"f26bcfa2beb15703482c764b92e8171f",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108695259,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"Almolonga",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/526/1/1108695261.geojson
+++ b/data/110/869/526/1/1108695261.geojson
@@ -126,6 +126,7 @@
         "hasc:id":"GT.GU.AM",
         "wd:id":"Q455760"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493567,
     "wof:geomhash":"a890eb611d24bc1ffc0aa5a52c084d44",
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108695261,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Amatitlan",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/526/3/1108695263.geojson
+++ b/data/110/869/526/3/1108695263.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.JU.AM",
         "wd:id":"Q2608750"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493569,
     "wof:geomhash":"c70777db6af39c03125720aef779f308",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695263,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Asuncion Mita",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/526/5/1108695265.geojson
+++ b/data/110/869/526/5/1108695265.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.JU.AT",
         "wd:id":"Q2403627"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493571,
     "wof:geomhash":"84bfb5ed23371967c1510cae239d2727",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695265,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Atescatempa",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/526/9/1108695269.geojson
+++ b/data/110/869/526/9/1108695269.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"GT.SM.AY",
         "wd:id":"Q2305570"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493572,
     "wof:geomhash":"49b328b4decd192d9a59de0b70586194",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108695269,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886112,
     "wof:name":"Ayutla",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/527/1/1108695271.geojson
+++ b/data/110/869/527/1/1108695271.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SR.BA",
         "wd:id":"Q2718316"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493575,
     "wof:geomhash":"f8bf978a19c9b44d60f5a1f64f3ebd64",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695271,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Barberena",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/527/3/1108695273.geojson
+++ b/data/110/869/527/3/1108695273.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"GT.QZ.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493577,
     "wof:geomhash":"12480f97b5c203941071095078c2c806",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695273,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886628,
     "wof:name":"Cabanas",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/110/869/527/5/1108695275.geojson
+++ b/data/110/869/527/5/1108695275.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.AV.CB",
         "wd:id":"Q2403031"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493579,
     "wof:geomhash":"87a7d2b09881a805be7326dedee5b159",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695275,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Cabrican",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/527/7/1108695277.geojson
+++ b/data/110/869/527/7/1108695277.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"GT.CQ.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493583,
     "wof:geomhash":"bd463c4ff316f1b198fc28eb8ff5d489",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695277,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886628,
     "wof:name":"Cajola",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/527/9/1108695279.geojson
+++ b/data/110/869/527/9/1108695279.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"GT.QC.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493584,
     "wof:geomhash":"c80957a46dd969ea586dc85e9f8c89d9",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695279,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886628,
     "wof:name":"Camotan",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/110/869/528/1/1108695281.geojson
+++ b/data/110/869/528/1/1108695281.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"GT.SM.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493588,
     "wof:geomhash":"f0f972bd854f6f1b29628d851b67008e",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108695281,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Casillas",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/528/3/1108695283.geojson
+++ b/data/110/869/528/3/1108695283.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.AV.CH",
         "wd:id":"Q1748875"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493590,
     "wof:geomhash":"ed13980a7d497c78634dee01ea9e7723",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695283,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886628,
     "wof:name":"Catarina",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/528/7/1108695287.geojson
+++ b/data/110/869/528/7/1108695287.geojson
@@ -92,6 +92,7 @@
     "wof:concordances":{
         "hasc:id":"GT.RE.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493592,
     "wof:geomhash":"a375391bfccbc6b9dd95ef6a9605cfc3",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108695287,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Chajul",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/528/9/1108695289.geojson
+++ b/data/110/869/528/9/1108695289.geojson
@@ -89,6 +89,7 @@
     "wof:concordances":{
         "hasc:id":"GT.SU.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493595,
     "wof:geomhash":"74b34bb640706f6fb651162df4ffbb6b",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108695289,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Chiantla",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/529/1/1108695291.geojson
+++ b/data/110/869/529/1/1108695291.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"GT.QC.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493597,
     "wof:geomhash":"8a5c63d0d86c29e8cf2aff9c2960f8bd",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695291,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886628,
     "wof:name":"Chicaman",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/529/3/1108695293.geojson
+++ b/data/110/869/529/3/1108695293.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.QC.CQ",
         "wd:id":"Q1025536"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493602,
     "wof:geomhash":"59e596753cadc239b808166d6877ffde",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695293,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Chinique",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/529/5/1108695295.geojson
+++ b/data/110/869/529/5/1108695295.geojson
@@ -99,7 +99,7 @@
         }
     ],
     "wof:id":1108695295,
-    "wof:lastmodified":1694639688,
+    "wof:lastmodified":1695886333,
     "wof:name":"Chuarrancho",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/529/7/1108695297.geojson
+++ b/data/110/869/529/7/1108695297.geojson
@@ -111,6 +111,7 @@
         "hasc:id":"GT.QZ.CP",
         "wd:id":"Q2445821"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493609,
     "wof:geomhash":"f74823b6a7f488bacd9331b4d01db332",
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108695297,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Coatepeque",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/529/9/1108695299.geojson
+++ b/data/110/869/529/9/1108695299.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.JU.CM",
         "wd:id":"Q2716888"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493614,
     "wof:geomhash":"788263f1e409f554c5067eda5006a7f7",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695299,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Comapa",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/530/1/1108695301.geojson
+++ b/data/110/869/530/1/1108695301.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SM.CO",
         "wd:id":"Q2716941"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493615,
     "wof:geomhash":"e18147bc2a8984823832d230f3987d9c",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695301,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886334,
     "wof:name":"Comitancillo",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/530/5/1108695305.geojson
+++ b/data/110/869/530/5/1108695305.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.QZ.CC",
         "wd:id":"Q2401883"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493617,
     "wof:geomhash":"d4b3c964eea5b5035665551b3f64e762",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695305,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886334,
     "wof:name":"Concepcion Chiquirichapa",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/530/7/1108695307.geojson
+++ b/data/110/869/530/7/1108695307.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.HU.CH",
         "wd:id":"Q2402377"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493619,
     "wof:geomhash":"e1caddddbd2b6333cfa2af3c9a5e4567",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695307,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886334,
     "wof:name":"Concepcion Huista",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/530/9/1108695309.geojson
+++ b/data/110/869/530/9/1108695309.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SM.CT",
         "wd:id":"Q1748770"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493622,
     "wof:geomhash":"2834592492c1dff565e04226bfff0bc2",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695309,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886334,
     "wof:name":"Concepcion Tutuapa",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/531/1/1108695311.geojson
+++ b/data/110/869/531/1/1108695311.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.JU.CG",
         "wd:id":"Q2403007"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493624,
     "wof:geomhash":"5eeccde44730e891f9d77e5e1c37c1b3",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695311,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Conguago",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/531/3/1108695313.geojson
+++ b/data/110/869/531/3/1108695313.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.BV.CU",
         "wd:id":"Q2034094"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493625,
     "wof:geomhash":"3501bc1fb3206316c4203ae76a8f9484",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695313,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Cubulco",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/110/869/531/5/1108695315.geojson
+++ b/data/110/869/531/5/1108695315.geojson
@@ -141,6 +141,7 @@
         "hasc:id":"GT.HU.CU",
         "wd:id":"Q2402387"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493628,
     "wof:geomhash":"050d2fae5864dfd23d5a4622bd3349f6",
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108695315,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886113,
     "wof:name":"Cuilco",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/531/7/1108695317.geojson
+++ b/data/110/869/531/7/1108695317.geojson
@@ -87,6 +87,7 @@
     "wof:concordances":{
         "hasc:id":"GT.SU.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493631,
     "wof:geomhash":"b5422669dd2f9b4a23e61f3f7e187edb",
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108695317,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Cuyotenango",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/531/9/1108695319.geojson
+++ b/data/110/869/531/9/1108695319.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.JU.EA",
         "wd:id":"Q3049691"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493635,
     "wof:geomhash":"7c6bcc9bcb788cbbc6c0a150aea16feb",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695319,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"El Adelanto",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/532/3/1108695323.geojson
+++ b/data/110/869/532/3/1108695323.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.BV.EC",
         "wd:id":"Q1727528"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493637,
     "wof:geomhash":"03334e477548100f6563385509744651",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695323,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"El Chol",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/110/869/532/5/1108695325.geojson
+++ b/data/110/869/532/5/1108695325.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GT.PR.EJ",
         "wd:id":"Q984828"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493639,
     "wof:geomhash":"b297a3352e8db852d0abadd2b67acaee",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108695325,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"El Jicaro",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/110/869/532/7/1108695327.geojson
+++ b/data/110/869/532/7/1108695327.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GT.QZ.EP",
         "wd:id":"Q2717583"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493641,
     "wof:geomhash":"cbc8acb86f0b509edac7ca583749b4ec",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108695327,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"El Palmar",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/532/9/1108695329.geojson
+++ b/data/110/869/532/9/1108695329.geojson
@@ -138,6 +138,7 @@
         "hasc:id":"GT.JU.EP",
         "wd:id":"Q686756"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493643,
     "wof:geomhash":"ab0dc1d3d86899eb93f7e76d648f3bcd",
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108695329,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886113,
     "wof:name":"El Progreso",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/533/1/1108695331.geojson
+++ b/data/110/869/533/1/1108695331.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SM.EQ",
         "wd:id":"Q1748870"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493645,
     "wof:geomhash":"b936e34c094b6944ab17e6d4699dedcb",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695331,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"El Quetzal",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/533/3/1108695333.geojson
+++ b/data/110/869/533/3/1108695333.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SM.ER",
         "wd:id":"Q579733"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493646,
     "wof:geomhash":"fe4eb6a4ea49c3fe05450588a26a9da6",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695333,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886628,
     "wof:name":"El Rodeo",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/533/5/1108695335.geojson
+++ b/data/110/869/533/5/1108695335.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.CM.ET",
         "wd:id":"Q1573447"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493647,
     "wof:geomhash":"473b051d282f0303648a3e73a1089982",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695335,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"El Tejar",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/110/869/533/7/1108695337.geojson
+++ b/data/110/869/533/7/1108695337.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SM.ET",
         "wd:id":"Q2422887"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493649,
     "wof:geomhash":"494ecd1f1526411ee87b38c56be81ef6",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695337,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"El Tumbador",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/534/1/1108695341.geojson
+++ b/data/110/869/534/1/1108695341.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SM.EP",
         "wd:id":"Q1748873"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493651,
     "wof:geomhash":"e7c186b47a50eb412da8156d285c465f",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695341,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Esquipulas Palo Gordo",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/534/3/1108695343.geojson
+++ b/data/110/869/534/3/1108695343.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.ZA.ES",
         "wd:id":"Q1020422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493653,
     "wof:geomhash":"3df6abc090fd5273318d9b90bf0354a4",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695343,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Estanzuela",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/110/869/534/5/1108695345.geojson
+++ b/data/110/869/534/5/1108695345.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.QZ.FC",
         "wd:id":"Q1981317"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493655,
     "wof:geomhash":"bfeb43c589a0fdb2f5853d6c3c012666",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695345,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Flores Costa Cuca",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/534/7/1108695347.geojson
+++ b/data/110/869/534/7/1108695347.geojson
@@ -168,6 +168,7 @@
         "hasc:id":"GT.PE.FL",
         "wd:id":"Q679383"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493657,
     "wof:geomhash":"07c704b58795ee5aabd7536b26f0bb54",
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1108695347,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886112,
     "wof:name":"Flores",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/110/869/534/9/1108695349.geojson
+++ b/data/110/869/534/9/1108695349.geojson
@@ -84,6 +84,7 @@
         "hasc:id":"GT.AV.FB",
         "wd:id":"Q275951"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493659,
     "wof:geomhash":"4b304ad09136a2774590d7ea74fb328a",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108695349,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Fray Bartolome De Las Casas",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/110/869/535/1/1108695351.geojson
+++ b/data/110/869/535/1/1108695351.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.QZ.GE",
         "wd:id":"Q3123016"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493661,
     "wof:geomhash":"c183091b8343640916fca4fedc6fd6ab",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695351,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886112,
     "wof:name":"Genova",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/535/3/1108695353.geojson
+++ b/data/110/869/535/3/1108695353.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.BV.GR",
         "wd:id":"Q611941"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493662,
     "wof:geomhash":"e565ae5da1c081803791c3cc7092768b",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695353,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Granados",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/110/869/535/5/1108695355.geojson
+++ b/data/110/869/535/5/1108695355.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.ES.GU",
         "wd:id":"Q1748573"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493665,
     "wof:geomhash":"282ae1565ab26ffa978ac65673ff625a",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695355,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Guanagazapa",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/110/869/535/9/1108695359.geojson
+++ b/data/110/869/535/9/1108695359.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SR.GU",
         "wd:id":"Q2401701"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493668,
     "wof:geomhash":"ead8fb2471422c57238122d82572a436",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695359,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886332,
     "wof:name":"Guazacapan",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/536/1/1108695361.geojson
+++ b/data/110/869/536/1/1108695361.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.QZ.HU",
         "wd:id":"Q1748611"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493671,
     "wof:geomhash":"a28065bb88855a0d5a9be51e006eae04",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695361,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Huitan",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/536/3/1108695363.geojson
+++ b/data/110/869/536/3/1108695363.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.ZA.HU",
         "wd:id":"Q1020827"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493672,
     "wof:geomhash":"b470a72c7d89604fc4bd0e56e766fafa",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695363,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Huite",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/110/869/536/5/1108695365.geojson
+++ b/data/110/869/536/5/1108695365.geojson
@@ -108,6 +108,7 @@
         "hasc:id":"GT.SM.IX",
         "wd:id":"Q2609056"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493674,
     "wof:geomhash":"c68dc027f4d642486c46fd551e7421b8",
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108695365,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Ixchiguan",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/536/7/1108695367.geojson
+++ b/data/110/869/536/7/1108695367.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.ES.IZ",
         "wd:id":"Q2401869"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493676,
     "wof:geomhash":"589d20e8283a69e99298cac8749122d3",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695367,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Iztapa",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/110/869/536/9/1108695369.geojson
+++ b/data/110/869/536/9/1108695369.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.JU.JA",
         "wd:id":"Q676590"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493679,
     "wof:geomhash":"b392448e3d9abe156134e15b2930c97e",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695369,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Jalpatagua",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/537/1/1108695371.geojson
+++ b/data/110/869/537/1/1108695371.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.JU.JE",
         "wd:id":"Q1749094"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493680,
     "wof:geomhash":"04ef6c3a189320e8ed458a17ec9337d4",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695371,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886334,
     "wof:name":"Jerez",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/537/3/1108695373.geojson
+++ b/data/110/869/537/3/1108695373.geojson
@@ -89,6 +89,7 @@
     "wof:concordances":{
         "hasc:id":"GT.HU.LD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493686,
     "wof:geomhash":"a453b9f3b2d09d02beff5ff10b4d9201",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108695373,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886334,
     "wof:name":"La Democracia",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/537/7/1108695377.geojson
+++ b/data/110/869/537/7/1108695377.geojson
@@ -137,6 +137,7 @@
     "wof:concordances":{
         "hasc:id":"GT.PE.LL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493690,
     "wof:geomhash":"f8e7a68b6c4d465c79c1d62efa0eeefa",
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108695377,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886113,
     "wof:name":"La Libertad",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/110/869/537/9/1108695379.geojson
+++ b/data/110/869/537/9/1108695379.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SM.LR",
         "wd:id":"Q1748856"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493691,
     "wof:geomhash":"f7bbc06f88b5f1f725cd2b6014c8c3ce",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695379,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"La Reforma",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/538/1/1108695381.geojson
+++ b/data/110/869/538/1/1108695381.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GT.ZA.LU",
         "wd:id":"Q1005750"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493698,
     "wof:geomhash":"2c5fa852623fe66ed3424e64b8be8ca3",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108695381,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886113,
     "wof:name":"La Union",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/110/869/538/3/1108695383.geojson
+++ b/data/110/869/538/3/1108695383.geojson
@@ -128,7 +128,7 @@
         }
     ],
     "wof:id":1108695383,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886335,
     "wof:name":"Lake Amatitlan",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/538/5/1108695385.geojson
+++ b/data/110/869/538/5/1108695385.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695385,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886328,
     "wof:name":"Lake Atitlan",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/110/869/538/7/1108695387.geojson
+++ b/data/110/869/538/7/1108695387.geojson
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":1108695387,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886335,
     "wof:name":"Lake Izabal",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/110/869/538/9/1108695389.geojson
+++ b/data/110/869/538/9/1108695389.geojson
@@ -162,6 +162,7 @@
         "hasc:id":"GT.IZ.LI",
         "wd:id":"Q1192713"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493706,
     "wof:geomhash":"5cd631c0f84eefbce2eaceef2a4394a9",
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108695389,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886113,
     "wof:name":"Livingston",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/110/869/539/1/1108695391.geojson
+++ b/data/110/869/539/1/1108695391.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SA.MM",
         "wd:id":"Q2401074"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493709,
     "wof:geomhash":"73e20d7fcdbb5e172bde81051498ae8f",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695391,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"Magdalena Milpas Altas",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/110/869/539/5/1108695395.geojson
+++ b/data/110/869/539/5/1108695395.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.ES.MA",
         "wd:id":"Q1748359"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493712,
     "wof:geomhash":"0fefb6747d85ce3d74f29b37881f514c",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695395,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"Masagua",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/110/869/539/7/1108695397.geojson
+++ b/data/110/869/539/7/1108695397.geojson
@@ -162,6 +162,7 @@
         "hasc:id":"GT.SU.MA",
         "wd:id":"Q1023983"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493715,
     "wof:geomhash":"45274ef3aea58cc0f692c0e25b64a6ae",
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108695397,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886113,
     "wof:name":"Mazatenango",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/539/9/1108695399.geojson
+++ b/data/110/869/539/9/1108695399.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.TO.MO",
         "wd:id":"Q2718095"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493718,
     "wof:geomhash":"b9a75fcd4d039f4a15e94df66ae1aad4",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695399,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"Momostenango",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/110/869/540/1/1108695401.geojson
+++ b/data/110/869/540/1/1108695401.geojson
@@ -264,6 +264,7 @@
         "hasc:id":"GT.JA.MO",
         "wd:id":"Q2608718"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493720,
     "wof:geomhash":"f07432d0f3fd6a8e4501ed968c779728",
@@ -276,7 +277,7 @@
         }
     ],
     "wof:id":1108695401,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"Monjas",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/110/869/540/3/1108695403.geojson
+++ b/data/110/869/540/3/1108695403.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.PR.MO",
         "wd:id":"Q1020416"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493722,
     "wof:geomhash":"86d977a428bcd83ba07e86450f7716e1",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695403,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"Morazan",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/110/869/540/5/1108695405.geojson
+++ b/data/110/869/540/5/1108695405.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.JU.MO",
         "wd:id":"Q2403612"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493723,
     "wof:geomhash":"7177bf6ee91f6cab9966c9a1f6ecaf5c",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695405,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"Moyuta",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/540/7/1108695407.geojson
+++ b/data/110/869/540/7/1108695407.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.HU.NE",
         "wd:id":"Q2402097"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493726,
     "wof:geomhash":"57cb5283f12ea4bf6e669800fddb8a65",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695407,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"Nenton",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/540/9/1108695409.geojson
+++ b/data/110/869/540/9/1108695409.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SM.NP",
         "wd:id":"Q3879296"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493729,
     "wof:geomhash":"f9a013202a29c8c6be9102da2e70d04a",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695409,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"Nuevo Progreso",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/541/3/1108695413.geojson
+++ b/data/110/869/541/3/1108695413.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GT.RE.NS",
         "wd:id":"Q6046952"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493731,
     "wof:geomhash":"c5d1b4746bd3d3bff6517ea71ed536ae",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108695413,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"Nuevo San Carlos",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/110/869/541/5/1108695415.geojson
+++ b/data/110/869/541/5/1108695415.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.SM.OC",
         "wd:id":"Q1748759"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493732,
     "wof:geomhash":"16ae0e119fff66af6ad12bb010144fbe",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695415,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"Ocos",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/541/7/1108695417.geojson
+++ b/data/110/869/541/7/1108695417.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.QZ.OL",
         "wd:id":"Q2608428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493734,
     "wof:geomhash":"0b5b0458aafa57394dff76e4dcc03b79",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695417,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"Olintepeque",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/541/9/1108695419.geojson
+++ b/data/110/869/541/9/1108695419.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.CQ.OL",
         "wd:id":"Q2025333"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493736,
     "wof:geomhash":"a28aec4311f61cc4dce171cfbebd4e24",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695419,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"Olopa",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/110/869/542/1/1108695421.geojson
+++ b/data/110/869/542/1/1108695421.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.SR.OR",
         "wd:id":"Q3884406"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493737,
     "wof:geomhash":"32a025f0f4ea6a4b7ee77fe2c4add682",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695421,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"Oratorio",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/542/3/1108695423.geojson
+++ b/data/110/869/542/3/1108695423.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.QC.PC",
         "wd:id":"Q2402484"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493739,
     "wof:geomhash":"f355fef33b189e9e693d0b77ac6c3f0d",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695423,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Pachalum",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/542/5/1108695425.geojson
+++ b/data/110/869/542/5/1108695425.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SM.PA",
         "wd:id":"Q2402391"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493741,
     "wof:geomhash":"a3e82ca3903d3539eb6e8460a2c84eeb",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695425,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886334,
     "wof:name":"Pajapita",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/542/7/1108695427.geojson
+++ b/data/110/869/542/7/1108695427.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"GT.GU.PA",
         "wd:id":"Q246164"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493742,
     "wof:geomhash":"88bc7debe29514c52573c8757ad7df23",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108695427,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886113,
     "wof:name":"Palencia",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/543/1/1108695431.geojson
+++ b/data/110/869/543/1/1108695431.geojson
@@ -91,6 +91,7 @@
         "hasc:id":"GT.QZ.PA",
         "wd:id":"Q2402624"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493744,
     "wof:geomhash":"14476b2b5a7ce22e9539e3219f5be6e8",
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108695431,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Palestina De Los Altos",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/543/3/1108695433.geojson
+++ b/data/110/869/543/3/1108695433.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.AV.PA",
         "wd:id":"Q2050264"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493747,
     "wof:geomhash":"ce9b55f29ce0706985403a2e996c5435",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695433,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Panzos",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/110/869/543/5/1108695435.geojson
+++ b/data/110/869/543/5/1108695435.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.CM.PR",
         "wd:id":"Q509612"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493748,
     "wof:geomhash":"4d800a592416bbf9b6f518053995e1c8",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695435,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886332,
     "wof:name":"Parramos",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/110/869/543/7/1108695437.geojson
+++ b/data/110/869/543/7/1108695437.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.JU.PA",
         "wd:id":"Q371987"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493750,
     "wof:geomhash":"1cde30317d98a621b875df8d9cc3dd90",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695437,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Pasaco",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/543/9/1108695439.geojson
+++ b/data/110/869/543/9/1108695439.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SU.PA",
         "wd:id":"Q2608585"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493753,
     "wof:geomhash":"66855d6fa210c58876be0d11e8df7cd1",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695439,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Patulul",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/544/1/1108695441.geojson
+++ b/data/110/869/544/1/1108695441.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.QC.IX",
         "wd:id":"Q2609036"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493759,
     "wof:geomhash":"2eba8bcebd17bebfb4ce173234530c8d",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695441,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"Playa Grande Ixcan",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/544/3/1108695443.geojson
+++ b/data/110/869/544/3/1108695443.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SR.PN",
         "wd:id":"Q2402134"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493762,
     "wof:geomhash":"c28ae4c0d8e8861eea3d842acc64b1af",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695443,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Pueblo Nuevo Vinas",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/544/5/1108695445.geojson
+++ b/data/110/869/544/5/1108695445.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SU.PN",
         "wd:id":"Q3925380"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493765,
     "wof:geomhash":"049d51a2a7ea05f61fcbd508a92e738f",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695445,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"Pueblo Nuevo",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/544/9/1108695449.geojson
+++ b/data/110/869/544/9/1108695449.geojson
@@ -222,6 +222,7 @@
         "hasc:id":"GT.IZ.PB",
         "wd:id":"Q991400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493766,
     "wof:geomhash":"bd3848b249e75e38f25af62dc8e303f8",
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":1108695449,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Puerto Barrios",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/110/869/545/1/1108695451.geojson
+++ b/data/110/869/545/1/1108695451.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"GT.JU.QU",
         "wd:id":"Q2403641"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493769,
     "wof:geomhash":"b4f847f1e46ae4ef40dfd6cbb10f511d",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108695451,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886113,
     "wof:name":"Quesada",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/545/3/1108695453.geojson
+++ b/data/110/869/545/3/1108695453.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.CQ.QU",
         "wd:id":"Q1981325"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493772,
     "wof:geomhash":"73116b82de691eabfa02822e96d249f7",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695453,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Quetzaltepeque",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/110/869/545/5/1108695455.geojson
+++ b/data/110/869/545/5/1108695455.geojson
@@ -100,7 +100,7 @@
         }
     ],
     "wof:id":1108695455,
-    "wof:lastmodified":1694639688,
+    "wof:lastmodified":1695886333,
     "wof:name":"Quiche",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/545/7/1108695457.geojson
+++ b/data/110/869/545/7/1108695457.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SM.RB",
         "wd:id":"Q3943212"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493777,
     "wof:geomhash":"04e8427eed46b0ee73701cb6d12a0cdf",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695457,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"Rio Blanco",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/545/9/1108695459.geojson
+++ b/data/110/869/545/9/1108695459.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.SU.RB",
         "wd:id":"Q1748849"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493779,
     "wof:geomhash":"dd0676d07308383c01d1b8fe18360cf8",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695459,
-    "wof:lastmodified":1694492401,
+    "wof:lastmodified":1695886333,
     "wof:name":"Rio Bravo",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/546/1/1108695461.geojson
+++ b/data/110/869/546/1/1108695461.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SU.SA",
         "wd:id":"Q371216"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493784,
     "wof:geomhash":"6220e8e9d23cab27a5354575b9e563e9",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695461,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"Samayac",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/546/3/1108695463.geojson
+++ b/data/110/869/546/3/1108695463.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.QC.AS",
         "wd:id":"Q2226684"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493789,
     "wof:geomhash":"974cb64f98c3136d7254639717c9d9e5",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695463,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"San Andres Sajcabaja",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/546/7/1108695467.geojson
+++ b/data/110/869/546/7/1108695467.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.PE.SA",
         "wd:id":"Q1005008"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493794,
     "wof:geomhash":"dd7d60b8b4120a60b3e5595a6edcc5bd",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695467,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"San Andres",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/110/869/546/9/1108695469.geojson
+++ b/data/110/869/546/9/1108695469.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.RE.AV",
         "wd:id":"Q2401685"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493796,
     "wof:geomhash":"d950876682d36b59d85e68d1f442a80c",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695469,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"San Andrez Villa Seca",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/110/869/547/1/1108695471.geojson
+++ b/data/110/869/547/1/1108695471.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SA.AA",
         "wd:id":"Q630216"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493798,
     "wof:geomhash":"1ac285224d915ecceac85eec661b7032",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695471,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Antonio Aguas Calientes",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/110/869/547/3/1108695473.geojson
+++ b/data/110/869/547/3/1108695473.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.HU.AH",
         "wd:id":"Q2609240"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493799,
     "wof:geomhash":"dcb43023e421424a6df7cd1fb0f9f9b7",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695473,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Antonio Huista",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/547/5/1108695475.geojson
+++ b/data/110/869/547/5/1108695475.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.QC.AI",
         "wd:id":"Q2401893"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493801,
     "wof:geomhash":"79fed5bddb8b261323e9c0db67bc38e9",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695475,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Antonio Ilotenango",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/547/7/1108695477.geojson
+++ b/data/110/869/547/7/1108695477.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.PR.AP",
         "wd:id":"Q962852"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493803,
     "wof:geomhash":"93986f4fbccd3670b444f557e8199a5d",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695477,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Antonio La Paz",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/110/869/547/9/1108695479.geojson
+++ b/data/110/869/547/9/1108695479.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SU.AS",
         "wd:id":"Q1748818"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493807,
     "wof:geomhash":"db3ff05d692bebd9722353c32340ee4b",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695479,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Antonio Suchitepequez",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/548/1/1108695481.geojson
+++ b/data/110/869/548/1/1108695481.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.QC.BJ",
         "wd:id":"Q2402363"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493809,
     "wof:geomhash":"576a7f708706bbfad2a6db6da44f399f",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695481,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886338,
     "wof:name":"San Bartolome Jocotenango",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/548/5/1108695485.geojson
+++ b/data/110/869/548/5/1108695485.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SA.BM",
         "wd:id":"Q2401093"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493811,
     "wof:geomhash":"08241063ecbe43f0d81743260fe78f40",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695485,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886339,
     "wof:name":"San Bartolome Milpas Altas",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/110/869/548/7/1108695487.geojson
+++ b/data/110/869/548/7/1108695487.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.TO.SB",
         "wd:id":"Q2401769"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493813,
     "wof:geomhash":"cfb97dafa09c6a4c28f7a07312193b04",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695487,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886339,
     "wof:name":"San Bartolo",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/110/869/548/9/1108695489.geojson
+++ b/data/110/869/548/9/1108695489.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SU.SB",
         "wd:id":"Q1748616"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493816,
     "wof:geomhash":"9679dd473abef7416ce9cc30563d3ff4",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695489,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886339,
     "wof:name":"San Bernandino",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/549/1/1108695491.geojson
+++ b/data/110/869/549/1/1108695491.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.JA.CA",
         "wd:id":"Q2403579"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493817,
     "wof:geomhash":"b735316a202b42dd5e09840e480ac101",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695491,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Carlos Alzatate",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/110/869/549/3/1108695493.geojson
+++ b/data/110/869/549/3/1108695493.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.QZ.CS",
         "wd:id":"Q2609256"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493819,
     "wof:geomhash":"f9d29da3cef4a9936a3e6147c7865f8d",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695493,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Carlos Sija",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/549/5/1108695495.geojson
+++ b/data/110/869/549/5/1108695495.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.PR.CA",
         "wd:id":"Q1020799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493821,
     "wof:geomhash":"592ef11cbfc321fbbac3b4f320aa79f7",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695495,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Cristobal Acasaguastlan",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/110/869/549/7/1108695497.geojson
+++ b/data/110/869/549/7/1108695497.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SM.CC",
         "wd:id":"Q1748857"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493822,
     "wof:geomhash":"d72cdb7bc8efe37b537a4f843b6a4ddb",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695497,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Cristobal Cuchu",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/549/9/1108695499.geojson
+++ b/data/110/869/549/9/1108695499.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.ZA.SD",
         "wd:id":"Q984445"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493826,
     "wof:geomhash":"1f56717171ba2908c840c45eb553c407",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695499,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Diego",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/110/869/550/3/1108695503.geojson
+++ b/data/110/869/550/3/1108695503.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.RE.SF",
         "wd:id":"Q1748865"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493828,
     "wof:geomhash":"98937d845e12b31fc3e8433128c2b991",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695503,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"San Felipe Retalhuleu",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/110/869/550/5/1108695505.geojson
+++ b/data/110/869/550/5/1108695505.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.QZ.FU",
         "wd:id":"Q2402566"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493830,
     "wof:geomhash":"0f97d3c3df5e6a2d36f8b2b3466b4dff",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695505,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886332,
     "wof:name":"San Francisco La Union",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/550/7/1108695507.geojson
+++ b/data/110/869/550/7/1108695507.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"GT.SU.FZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493832,
     "wof:geomhash":"c4d84193593cd7d9c43bea4639112403",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695507,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"San Francisco Zapotitlan",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/550/9/1108695509.geojson
+++ b/data/110/869/550/9/1108695509.geojson
@@ -87,6 +87,7 @@
     "wof:concordances":{
         "hasc:id":"GT.HU.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493836,
     "wof:geomhash":"9e259093489833123bebd3a911faf6fd",
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108695509,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"San Gaspar Ixchil",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/551/1/1108695511.geojson
+++ b/data/110/869/551/1/1108695511.geojson
@@ -100,6 +100,7 @@
         "hasc:id":"GT.HU.IX",
         "wd:id":"Q2401814"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493837,
     "wof:geomhash":"dbeb48675d67a0dee647de3f24d6e119",
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108695511,
-    "wof:lastmodified":1694492399,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Idelfonso Ixtahuacan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/551/3/1108695513.geojson
+++ b/data/110/869/551/3/1108695513.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.CQ.SJ",
         "wd:id":"Q978109"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493838,
     "wof:geomhash":"2b122583c73882db9b4e8d94bc0d63d4",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695513,
-    "wof:lastmodified":1694492399,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Jacinto",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/110/869/551/5/1108695515.geojson
+++ b/data/110/869/551/5/1108695515.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.BV.SJ",
         "wd:id":"Q962529"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493840,
     "wof:geomhash":"330eac3806bfe2282c3b7c5ee75c7296",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695515,
-    "wof:lastmodified":1694492399,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Jeronimo",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/110/869/551/7/1108695517.geojson
+++ b/data/110/869/551/7/1108695517.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"GT.JU.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493842,
     "wof:geomhash":"1bfc8b24305a6d64fd96973be2bb354b",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695517,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"San Jose Acatempa",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/552/1/1108695521.geojson
+++ b/data/110/869/552/1/1108695521.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.GU.JG",
         "wd:id":"Q275791"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493846,
     "wof:geomhash":"4c3824a6764a9c200f42832e59933e52",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695521,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"San Jose Del Golfo",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/552/3/1108695523.geojson
+++ b/data/110/869/552/3/1108695523.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SU.JI",
         "wd:id":"Q2401870"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493848,
     "wof:geomhash":"395ee773d095166e0ac06c8f9a60ab69",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695523,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"San Jose El Idolo",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/552/5/1108695525.geojson
+++ b/data/110/869/552/5/1108695525.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.CQ.JA",
         "wd:id":"Q1749098"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493849,
     "wof:geomhash":"f781ed9234fd796f0cf5f03703148bdd",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695525,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"San Jose La Arada",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/110/869/552/7/1108695527.geojson
+++ b/data/110/869/552/7/1108695527.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SM.JO",
         "wd:id":"Q1748795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493850,
     "wof:geomhash":"e7f82cea660d94f1a5d89e641bc5fb60",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695527,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"San Jose Ojetenan",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/552/9/1108695529.geojson
+++ b/data/110/869/552/9/1108695529.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GT.GU.JP",
         "wd:id":"Q317380"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493852,
     "wof:geomhash":"782fa64f95e345b53e8b0d9db3387abe",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108695529,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"San Jose Pinula",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/553/1/1108695531.geojson
+++ b/data/110/869/553/1/1108695531.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.CM.JP",
         "wd:id":"Q1254233"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493853,
     "wof:geomhash":"ff17898211e928b11e20f2804beaa2cd",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695531,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886336,
     "wof:name":"San Jose Poaquil",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/110/869/553/3/1108695533.geojson
+++ b/data/110/869/553/3/1108695533.geojson
@@ -104,6 +104,7 @@
     "wof:concordances":{
         "hasc:id":"GT.PE.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493856,
     "wof:geomhash":"6289b2a62d94f55998631d435092c23f",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108695533,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886114,
     "wof:name":"San Jose",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/110/869/553/5/1108695535.geojson
+++ b/data/110/869/553/5/1108695535.geojson
@@ -120,6 +120,7 @@
         "hasc:id":"GT.SU.JB",
         "wd:id":"Q1748787"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493859,
     "wof:geomhash":"88247da753e61d0b21ada319e01b6c72",
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108695535,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886114,
     "wof:name":"San Juan Bautista",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/553/9/1108695539.geojson
+++ b/data/110/869/553/9/1108695539.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.QZ.OS",
         "wd:id":"Q2718157"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493866,
     "wof:geomhash":"ec14f8d54d1a9c477c710db1019ff44d",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695539,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886336,
     "wof:name":"San Juan Ostuncalco",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/554/1/1108695541.geojson
+++ b/data/110/869/554/1/1108695541.geojson
@@ -86,6 +86,7 @@
     "wof:concordances":{
         "hasc:id":"GT.SR.JT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493868,
     "wof:geomhash":"8a64bb90cffd7f428c5ad1d2f0c19b3b",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108695541,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Juan Tecuaco",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/554/3/1108695543.geojson
+++ b/data/110/869/554/3/1108695543.geojson
@@ -183,6 +183,7 @@
     "wof:concordances":{
         "hasc:id":"GT.SU.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493870,
     "wof:geomhash":"4b7f29e3f61f945b663bb9df8831e3e9",
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":1108695543,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886114,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/554/5/1108695545.geojson
+++ b/data/110/869/554/5/1108695545.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.JA.LJ",
         "wd:id":"Q568999"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493873,
     "wof:geomhash":"291ec6e9c5ff6f02384f59f49b2792b0",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695545,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Luis Jilotepeque",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/110/869/554/7/1108695547.geojson
+++ b/data/110/869/554/7/1108695547.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.JA.MC",
         "wd:id":"Q1749101"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493876,
     "wof:geomhash":"c6cf1eb35fb5e7dcc572beaaa1bd35ca",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695547,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886337,
     "wof:name":"San Manuel Chaparron",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/110/869/554/9/1108695549.geojson
+++ b/data/110/869/554/9/1108695549.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SO.ML",
         "wd:id":"Q2402793"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493878,
     "wof:geomhash":"5786e2a5764e3c18757da54f72a23237",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695549,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886336,
     "wof:name":"San Marcos La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/110/869/555/1/1108695551.geojson
+++ b/data/110/869/555/1/1108695551.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.QZ.SS",
         "wd:id":"Q2402153"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493882,
     "wof:geomhash":"277c54b8f66a7ef160ca20a5db4a9680",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695551,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886334,
     "wof:name":"San Martin Sacatepequez",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/555/3/1108695553.geojson
+++ b/data/110/869/555/3/1108695553.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.RE.MZ",
         "wd:id":"Q1748755"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493883,
     "wof:geomhash":"707dd1728dae89a8b138cca1d43c4852",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695553,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"San Martin Zapotitlan",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/110/869/555/7/1108695557.geojson
+++ b/data/110/869/555/7/1108695557.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.HU.MI",
         "wd:id":"Q2609270"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493885,
     "wof:geomhash":"45303dbc55d2d4ff97ca8fdbe2315d7c",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695557,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"San Mateo Ixtatan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/555/9/1108695559.geojson
+++ b/data/110/869/555/9/1108695559.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.QZ.SM",
         "wd:id":"Q938168"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493887,
     "wof:geomhash":"35ace383c7e46803661bf8ccc32ecd3c",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695559,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886114,
     "wof:name":"San Mateo",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/556/1/1108695561.geojson
+++ b/data/110/869/556/1/1108695561.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"GT.HU.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493888,
     "wof:geomhash":"d7094b79253f99aa89207e7ad283d768",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695561,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"San Miguel Acatan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/556/3/1108695563.geojson
+++ b/data/110/869/556/3/1108695563.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.BV.MC",
         "wd:id":"Q1517461"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493890,
     "wof:geomhash":"97845380f195c9f57acfdce8059828a6",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695563,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Miguel Chicaj",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/110/869/556/5/1108695565.geojson
+++ b/data/110/869/556/5/1108695565.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SM.MI",
         "wd:id":"Q2402417"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493893,
     "wof:geomhash":"e0bc600e6425360d6baf352d944705bd",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695565,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Miguel Ixtahuacan",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/556/7/1108695567.geojson
+++ b/data/110/869/556/7/1108695567.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SU.MP",
         "wd:id":"Q2402447"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493895,
     "wof:geomhash":"3601d1eefaa78188d713de16a5e87f03",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695567,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Miguel Panna",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/556/9/1108695569.geojson
+++ b/data/110/869/556/9/1108695569.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.QZ.MS",
         "wd:id":"Q2401933"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493897,
     "wof:geomhash":"3864f60680f88a9d1486313ca6424e21",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695569,
-    "wof:lastmodified":1694492399,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Miguel Siguila",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/557/1/1108695571.geojson
+++ b/data/110/869/557/1/1108695571.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SU.PJ",
         "wd:id":"Q2716950"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493899,
     "wof:geomhash":"c25ceab4372aae1c209ba33c839c0857",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695571,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"San Pablo Jocopitas",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/557/5/1108695575.geojson
+++ b/data/110/869/557/5/1108695575.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.SM.SP",
         "wd:id":"Q3306697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493900,
     "wof:geomhash":"e2a1d650197f68c45828a390d4beb5d5",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695575,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886112,
     "wof:name":"San Pablo",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/557/7/1108695577.geojson
+++ b/data/110/869/557/7/1108695577.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GT.GU.SP",
         "wd:id":"Q275983"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493902,
     "wof:geomhash":"63e6a8ba27b8966e8c419991645a674f",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108695577,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"San Pedro Ayampuc",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/557/9/1108695579.geojson
+++ b/data/110/869/557/9/1108695579.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.QC.PJ",
         "wd:id":"Q2621511"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493905,
     "wof:geomhash":"92f3c232f36965128f07ecb32cee7d8e",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695579,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"San Pedro Jocopitas",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/558/1/1108695581.geojson
+++ b/data/110/869/558/1/1108695581.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.HU.PN",
         "wd:id":"Q734440"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493907,
     "wof:geomhash":"5161113fa327f2e99026a5ef29f4b2b0",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695581,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"San Pedro Necta",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/558/3/1108695583.geojson
+++ b/data/110/869/558/3/1108695583.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"GT.GU.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493909,
     "wof:geomhash":"83ab9ffd7eb767aac981189cddf17448",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695583,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"San Pedro Sacatepequez",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/558/5/1108695585.geojson
+++ b/data/110/869/558/5/1108695585.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"GT.SM.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493911,
     "wof:geomhash":"c7c2c90e46e9f75bfc20c9157db14a9d",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695585,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"San Pedro Sacatepequez",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/558/7/1108695587.geojson
+++ b/data/110/869/558/7/1108695587.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.HU.RI",
         "wd:id":"Q2401930"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493912,
     "wof:geomhash":"06841005b52a2ab793ba43fc7743802d",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695587,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"San Rafael Independencia",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/558/9/1108695589.geojson
+++ b/data/110/869/558/9/1108695589.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SR.RF",
         "wd:id":"Q1748669"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493914,
     "wof:geomhash":"455b70be1a279f4a2b95b44da79b5412",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695589,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"San Rafael Las Flores",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/559/3/1108695593.geojson
+++ b/data/110/869/559/3/1108695593.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.HU.RP",
         "wd:id":"Q2402524"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493915,
     "wof:geomhash":"7a28c2be0202fc3dc107e472a604a6b6",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695593,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"San Rafael Petzal",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/559/5/1108695595.geojson
+++ b/data/110/869/559/5/1108695595.geojson
@@ -88,6 +88,7 @@
         "hasc:id":"GT.SM.RP",
         "wd:id":"Q2402778"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493917,
     "wof:geomhash":"087fa9df0af53d909bb6a89379988637",
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108695595,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"San Rafael Pie De La Cuesta",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/559/7/1108695597.geojson
+++ b/data/110/869/559/7/1108695597.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.HU.SS",
         "wd:id":"Q2402150"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493920,
     "wof:geomhash":"8ec40b665aba925245747e4b89ad4cf7",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695597,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"San Sebastian Coatan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/559/9/1108695599.geojson
+++ b/data/110/869/559/9/1108695599.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.RE.SS",
         "wd:id":"Q2402108"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493922,
     "wof:geomhash":"d3545c6b3224ae790120d4e63019a37c",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695599,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"San Sebastian",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/110/869/560/1/1108695601.geojson
+++ b/data/110/869/560/1/1108695601.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"GT.SO.SA",
         "wd:id":"Q168622"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493924,
     "wof:geomhash":"9d1c70fdf4bb0ad7f3932e140d7025d0",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108695601,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Tiago Atitlan",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/110/869/560/3/1108695603.geojson
+++ b/data/110/869/560/3/1108695603.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.SA.SS",
         "wd:id":"Q2295832"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493926,
     "wof:geomhash":"86d9f02f8d30da68dcdbb4c0f880fb55",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695603,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886329,
     "wof:name":"San Tiago Sacatepequez",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/110/869/560/5/1108695605.geojson
+++ b/data/110/869/560/5/1108695605.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.PR.SR",
         "wd:id":"Q1757603"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493929,
     "wof:geomhash":"39a0f4690aebe948fead21389033966a",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695605,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Sanarate",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/110/869/560/7/1108695607.geojson
+++ b/data/110/869/560/7/1108695607.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.HU.SA",
         "wd:id":"Q2402405"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493930,
     "wof:geomhash":"1ddc07ab5bd33a0370a82fae682bc956",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695607,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886329,
     "wof:name":"Santa Ana Huista",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/561/1/1108695611.geojson
+++ b/data/110/869/561/1/1108695611.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.CM.SA",
         "wd:id":"Q1254653"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493932,
     "wof:geomhash":"3fdf1852223439c9ff6529f96cb057fb",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695611,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Santa Apolonia",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/110/869/561/3/1108695613.geojson
+++ b/data/110/869/561/3/1108695613.geojson
@@ -179,6 +179,7 @@
     "wof:concordances":{
         "hasc:id":"GT.SU.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493934,
     "wof:geomhash":"eaa962749a001b3275e406ae374608b2",
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":1108695613,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886112,
     "wof:name":"Santa Barbara",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/561/5/1108695615.geojson
+++ b/data/110/869/561/5/1108695615.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"GT.AV.CT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493936,
     "wof:geomhash":"12374e54d74e5ce19e0555fc52df634b",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695615,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"Santa Catalina La Tinta",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/110/869/561/7/1108695617.geojson
+++ b/data/110/869/561/7/1108695617.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SO.CI",
         "wd:id":"Q2402186"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493939,
     "wof:geomhash":"8f1b07688393c873dd7107d664010a0b",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695617,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Santa Catarina Ixtahuacan",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/110/869/561/9/1108695619.geojson
+++ b/data/110/869/561/9/1108695619.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.JU.SC",
         "wd:id":"Q1748953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493941,
     "wof:geomhash":"388541064d6378e032aeda05ce0d8d89",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695619,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Santa Catarina Mita",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/562/1/1108695621.geojson
+++ b/data/110/869/562/1/1108695621.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.GU.CP",
         "wd:id":"Q1671882"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493943,
     "wof:geomhash":"954ae226d60b14ac76edc202803983b6",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695621,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Santa Catarina Pinula",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/562/3/1108695623.geojson
+++ b/data/110/869/562/3/1108695623.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"GT.RE.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493949,
     "wof:geomhash":"a25a14365522d7d1b49e06c984bba98f",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695623,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"Santa Cruz Mulua",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/110/869/562/5/1108695625.geojson
+++ b/data/110/869/562/5/1108695625.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SR.CN",
         "wd:id":"Q979193"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493950,
     "wof:geomhash":"72dad5a6a2d128c66f9ff5bcc16f1ccb",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695625,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Santa Cruz Naranjo",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/562/9/1108695629.geojson
+++ b/data/110/869/562/9/1108695629.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.HU.SE",
         "wd:id":"Q1748868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493952,
     "wof:geomhash":"c1809608907433cdf074ca3ff1dc3967",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695629,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Santa Eulalia",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/563/1/1108695631.geojson
+++ b/data/110/869/563/1/1108695631.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SA.LM",
         "wd:id":"Q2400752"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493956,
     "wof:geomhash":"22adc8c3a1bf9fa75c1c6c6ca5ea930a",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695631,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Santa Lucia Milpas Altas",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/110/869/563/3/1108695633.geojson
+++ b/data/110/869/563/3/1108695633.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.SR.MI",
         "wd:id":"Q1748654"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493960,
     "wof:geomhash":"8b1b47f16921d7582bc90576a25a703e",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695633,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Santa Maria Ixtahuatan",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/563/5/1108695635.geojson
+++ b/data/110/869/563/5/1108695635.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SO.MV",
         "wd:id":"Q1748668"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493962,
     "wof:geomhash":"dbcaa0fb1d1a32283e08f87ece0dc125",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695635,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Santa Maria Visitacion",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/110/869/563/7/1108695637.geojson
+++ b/data/110/869/563/7/1108695637.geojson
@@ -84,6 +84,7 @@
         "hasc:id":"GT.SR.RL",
         "wd:id":"Q3949243"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493963,
     "wof:geomhash":"5c9bac8f4cb75957202f5aac6e735023",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108695637,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Santa Rosa De Lima",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/110/869/563/9/1108695639.geojson
+++ b/data/110/869/563/9/1108695639.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SU.DS",
         "wd:id":"Q2402403"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493966,
     "wof:geomhash":"0b37fb662024ddae3e64af64fb413525",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695639,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Santo Domingo Suchitepequez",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/564/1/1108695641.geojson
+++ b/data/110/869/564/1/1108695641.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SA.DX",
         "wd:id":"Q2401045"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493968,
     "wof:geomhash":"47fcafdfcd10336c949fed4b7ab459a2",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695641,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Santo Domingo Xenacoj",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/110/869/564/3/1108695643.geojson
+++ b/data/110/869/564/3/1108695643.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.SU.TU",
         "wd:id":"Q2402120"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493970,
     "wof:geomhash":"325692b51f60d1017fc1fbbc2b92190b",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695643,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Santo Tomas La Union",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/110/869/564/7/1108695647.geojson
+++ b/data/110/869/564/7/1108695647.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.AV.SE",
         "wd:id":"Q332072"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493974,
     "wof:geomhash":"bc262aae3b24cc70d3ba9f1deb21af6c",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695647,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Senahu",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/110/869/564/9/1108695649.geojson
+++ b/data/110/869/564/9/1108695649.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.QZ.SB",
         "wd:id":"Q2402599"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493975,
     "wof:geomhash":"6b380f1d73f35475bcb8bddd3904784d",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695649,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886335,
     "wof:name":"Sibilia",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/110/869/565/1/1108695651.geojson
+++ b/data/110/869/565/1/1108695651.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.SM.SB",
         "wd:id":"Q1748820"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493977,
     "wof:geomhash":"ea2027056b93a65f6475f114b2ef0681",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695651,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Sibinal",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/565/3/1108695653.geojson
+++ b/data/110/869/565/3/1108695653.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.SM.SC",
         "wd:id":"Q1748824"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493978,
     "wof:geomhash":"9cc43b73ac12517b08a54358cdf309d3",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695653,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Sipacapa",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/565/5/1108695655.geojson
+++ b/data/110/869/565/5/1108695655.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.ES.SI",
         "wd:id":"Q1748570"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493980,
     "wof:geomhash":"62c007f090cdf60e40b641cddd5cfe5f",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695655,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886336,
     "wof:name":"Siquinala",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/110/869/565/7/1108695657.geojson
+++ b/data/110/869/565/7/1108695657.geojson
@@ -94,6 +94,7 @@
         "hasc:id":"GT.HU.SO",
         "wd:id":"Q2402459"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493982,
     "wof:geomhash":"3d67b194d7ef6f26becd2ea1630879c5",
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108695657,
-    "wof:lastmodified":1694492402,
+    "wof:lastmodified":1695886336,
     "wof:name":"Soloma",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/565/9/1108695659.geojson
+++ b/data/110/869/565/9/1108695659.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SM.TN",
         "wd:id":"Q2401748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493984,
     "wof:geomhash":"b102d1b93a1a933c15fa33240eb096b3",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695659,
-    "wof:lastmodified":1694492403,
+    "wof:lastmodified":1695886336,
     "wof:name":"Tacana",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/566/1/1108695661.geojson
+++ b/data/110/869/566/1/1108695661.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.SM.TM",
         "wd:id":"Q1748863"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493987,
     "wof:geomhash":"d86dfeea3d3fddc1a05969906bd743f7",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695661,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Tajumulco",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/566/5/1108695665.geojson
+++ b/data/110/869/566/5/1108695665.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.AV.TM",
         "wd:id":"Q348216"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493988,
     "wof:geomhash":"e413dda458b53e146ad3ba71fd69dc8b",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695665,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Tamahu",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/110/869/566/7/1108695667.geojson
+++ b/data/110/869/566/7/1108695667.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"GT.HU.TE",
         "wd:id":"Q2402198"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493991,
     "wof:geomhash":"5b2212cc8f3a392c64376e210deaddb6",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695667,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Tectitan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/566/9/1108695669.geojson
+++ b/data/110/869/566/9/1108695669.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.ZA.TE",
         "wd:id":"Q1020568"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493993,
     "wof:geomhash":"9b3e6a0993c015b118063ff9a60ef7e0",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695669,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Teculutan",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/110/869/567/1/1108695671.geojson
+++ b/data/110/869/567/1/1108695671.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SM.TE",
         "wd:id":"Q1748860"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493994,
     "wof:geomhash":"0a4dd44f0c4c0a0dc4960f706bf2738c",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695671,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Tejutla",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/110/869/567/3/1108695673.geojson
+++ b/data/110/869/567/3/1108695673.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.ES.TI",
         "wd:id":"Q532226"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474493996,
     "wof:geomhash":"3321280928e6450b88ccf23bb2b8b552",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695673,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Tiquisate",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/110/869/567/5/1108695675.geojson
+++ b/data/110/869/567/5/1108695675.geojson
@@ -64,6 +64,7 @@
     "wof:concordances":{
         "hasc:id":"GT.HU.UC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474494000,
     "wof:geomhash":"df9142f38ebb810e6a21296e90f7d741",
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108695675,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886629,
     "wof:name":"Union Cantinil",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/110/869/567/7/1108695677.geojson
+++ b/data/110/869/567/7/1108695677.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.ZA.US",
         "wd:id":"Q203970"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474494003,
     "wof:geomhash":"578287c0cad7cf0187a7aacddb8f5790",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695677,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Usumatlan",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/110/869/567/9/1108695679.geojson
+++ b/data/110/869/567/9/1108695679.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"GT.GU.VC",
         "wd:id":"Q174266"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474494004,
     "wof:geomhash":"994c59ae28a590fbf4bd8bed5bd99501",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108695679,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Villa Canales",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/110/869/568/3/1108695683.geojson
+++ b/data/110/869/568/3/1108695683.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.CM.YE",
         "wd:id":"Q1523937"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474494006,
     "wof:geomhash":"80f3a9be79f265f396472f8c180c822b",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695683,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Yepocapa",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/110/869/568/5/1108695685.geojson
+++ b/data/110/869/568/5/1108695685.geojson
@@ -96,6 +96,7 @@
         "hasc:id":"GT.JU.YU",
         "wd:id":"Q1749697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474494008,
     "wof:geomhash":"e1fa3b3f76511607421754a1855be129",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108695685,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Yupiltepeque",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/568/7/1108695687.geojson
+++ b/data/110/869/568/7/1108695687.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.QC.ZA",
         "wd:id":"Q2723903"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474494011,
     "wof:geomhash":"f9e6781bcabca8655ae336dd3660268a",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695687,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Zacualpa",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/110/869/568/9/1108695689.geojson
+++ b/data/110/869/568/9/1108695689.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"GT.JU.ZA",
         "wd:id":"Q2610825"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474494012,
     "wof:geomhash":"8767fa5285d3fd0e0c18a5011ff0390c",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695689,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886331,
     "wof:name":"Zapotitlan",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/110/869/569/1/1108695691.geojson
+++ b/data/110/869/569/1/1108695691.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"GT.SU.ZU",
         "wd:id":"Q2608644"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1474494015,
     "wof:geomhash":"4671fa559c5b74bae40a54d86770209a",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108695691,
-    "wof:lastmodified":1694492400,
+    "wof:lastmodified":1695886330,
     "wof:name":"Zunilito",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/421/166/783/421166783.geojson
+++ b/data/421/166/783/421166783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065832,
-    "geom:area_square_m":785742448.712128,
+    "geom:area_square_m":785742697.453237,
     "geom:bbox":"-89.473259,15.002185,-89.152499,15.29765",
     "geom:latitude":15.146919,
     "geom:longitude":-89.302081,
@@ -132,12 +132,13 @@
         "qs_pg:id":273569,
         "wd:id":"Q1552683"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008702,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b2de55cca1a587c28abd7dea2efee318",
+    "wof:geomhash":"ddd2a7bc8649d11de6c3e487d7f90682",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421166783,
-    "wof:lastmodified":1690927649,
+    "wof:lastmodified":1695886025,
     "wof:name":"Gualan",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/421/166/811/421166811.geojson
+++ b/data/421/166/811/421166811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006427,
-    "geom:area_square_m":76639017.076693,
+    "geom:area_square_m":76638858.132576,
     "geom:bbox":"-90.455541,15.268194,-90.373202,15.403975",
     "geom:latitude":15.340561,
     "geom:longitude":-90.415767,
@@ -124,12 +124,13 @@
         "qs_pg:id":510773,
         "wd:id":"Q332059"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008703,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1bbd2959948b85ff09ffe82de02f1a98",
+    "wof:geomhash":"c643b8af0785159b6ec525948c9b6690",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421166811,
-    "wof:lastmodified":1690927648,
+    "wof:lastmodified":1695886025,
     "wof:name":"Santa Cruz Verapaz",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/166/847/421166847.geojson
+++ b/data/421/166/847/421166847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004826,
-    "geom:area_square_m":57730660.762108,
+    "geom:area_square_m":57730385.703961,
     "geom:bbox":"-91.32826,14.599436,-91.232046,14.750311",
     "geom:latitude":14.653473,
     "geom:longitude":-91.276127,
@@ -132,12 +132,13 @@
         "qs_pg:id":1264025,
         "wd:id":"Q2548707"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008704,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7df098276b60b364236dd79f25a42fce",
+    "wof:geomhash":"d80e51648ac194fc1715f3e7f00983ea",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421166847,
-    "wof:lastmodified":1690927650,
+    "wof:lastmodified":1695886025,
     "wof:name":"San Pedro La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/167/973/421167973.geojson
+++ b/data/421/167/973/421167973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00077,
-    "geom:area_square_m":9215610.98443,
+    "geom:area_square_m":9215658.120782,
     "geom:bbox":"-90.753262,14.564915,-90.71211,14.606942",
     "geom:latitude":14.58892,
     "geom:longitude":-90.733597,
@@ -120,12 +120,13 @@
         "wd:id":"Q2402824",
         "wk:page":"Cuyotenango"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008750,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42aa823771480c39633028aea93b26c9",
+    "wof:geomhash":"3e07926d235ddca7b3fd3a5185cdab6c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421167973,
-    "wof:lastmodified":1690927666,
+    "wof:lastmodified":1695886025,
     "wof:name":"Jocotenango",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/168/071/421168071.geojson
+++ b/data/421/168/071/421168071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045924,
-    "geom:area_square_m":550257892.065217,
+    "geom:area_square_m":550258041.931917,
     "geom:bbox":"-90.925775,14.145291,-90.657455,14.468487",
     "geom:latitude":14.300259,
     "geom:longitude":-90.793344,
@@ -252,12 +252,13 @@
         "qs_pg:id":978090,
         "wd:id":"Q780771"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008753,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c828786500f0034087a5dd41101b41ea",
+    "wof:geomhash":"975c5a5a37e09df90a5c679c0a9fb6cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -267,7 +268,7 @@
         }
     ],
     "wof:id":421168071,
-    "wof:lastmodified":1690927645,
+    "wof:lastmodified":1695886114,
     "wof:name":"Escuintla",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/169/433/421169433.geojson
+++ b/data/421/169/433/421169433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023469,
-    "geom:area_square_m":280612590.357158,
+    "geom:area_square_m":280612676.690908,
     "geom:bbox":"-90.767836,14.674183,-90.541608,14.880109",
     "geom:latitude":14.768874,
     "geom:longitude":-90.64823,
@@ -142,12 +142,13 @@
         "qs_pg:id":1263968,
         "wd:id":"Q127622"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008810,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"21702404a4fbda9da640f0dc400cc7cf",
+    "wof:geomhash":"37a1dad15b6c28d24527808fb1717afb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":421169433,
-    "wof:lastmodified":1690927672,
+    "wof:lastmodified":1695886025,
     "wof:name":"San Juan Sacatepequez",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/169/903/421169903.geojson
+++ b/data/421/169/903/421169903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07149,
-    "geom:area_square_m":851572545.939642,
+    "geom:area_square_m":851572545.939517,
     "geom:bbox":"-91.322799464,15.3773009935,-91.018549145,15.8313443618",
     "geom:latitude":15.563024,
     "geom:longitude":-91.171961,
@@ -106,12 +106,13 @@
         "qs_pg:id":1263992,
         "wd:id":"Q3132625"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"505d667b68d4981e836fc8230e1a4e63",
+    "wof:geomhash":"5abae736a623525a7dabfa944f6101a7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":421169903,
-    "wof:lastmodified":1582360592,
+    "wof:lastmodified":1695886025,
     "wof:name":"Nebaj",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/169/961/421169961.geojson
+++ b/data/421/169/961/421169961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031071,
-    "geom:area_square_m":370643175.729939,
+    "geom:area_square_m":370643156.26236,
     "geom:bbox":"-91.326061,15.196877,-90.946657,15.333928",
     "geom:latitude":15.263658,
     "geom:longitude":-91.11411,
@@ -121,12 +121,13 @@
         "qs_pg:id":772718,
         "wd:id":"Q2401849"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008831,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0ec4fbee279aa5f362c85f675177971",
+    "wof:geomhash":"bbd2cce8e5ec90f5a067bd3e60579487",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421169961,
-    "wof:lastmodified":1690927669,
+    "wof:lastmodified":1695886025,
     "wof:name":"Sacapulas",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/169/963/421169963.geojson
+++ b/data/421/169/963/421169963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006731,
-    "geom:area_square_m":80493010.60158,
+    "geom:area_square_m":80493221.849481,
     "geom:bbox":"-91.549021,14.679825,-91.441451,14.800882",
     "geom:latitude":14.742897,
     "geom:longitude":-91.496882,
@@ -127,12 +127,13 @@
         "qs_pg:id":772726,
         "wd:id":"Q230166"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008831,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"16ab946b06d5c641fedcbf87c8365f0e",
+    "wof:geomhash":"3beb23d430e04ba2df31a04cde5024d0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421169963,
-    "wof:lastmodified":1690927667,
+    "wof:lastmodified":1695886025,
     "wof:name":"Zunil",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/170/043/421170043.geojson
+++ b/data/421/170/043/421170043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009765,
-    "geom:area_square_m":116472077.408332,
+    "geom:area_square_m":116472152.597041,
     "geom:bbox":"-90.397913,15.231823,-90.273674,15.356131",
     "geom:latitude":15.297654,
     "geom:longitude":-90.340044,
@@ -175,12 +175,13 @@
         "qs_pg:id":1263965,
         "wd:id":"Q348201"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008834,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"92700ea334b0ef193416abcea514d843",
+    "wof:geomhash":"6fe9cee46f52a4b8d837599cee7cb3f6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":421170043,
-    "wof:lastmodified":1690927776,
+    "wof:lastmodified":1695886029,
     "wof:name":"Tactic",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/170/045/421170045.geojson
+++ b/data/421/170/045/421170045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042194,
-    "geom:area_square_m":504049743.017913,
+    "geom:area_square_m":504049906.105584,
     "geom:bbox":"-89.654075,14.855606,-89.32107,15.083281",
     "geom:latitude":14.963449,
     "geom:longitude":-89.485421,
@@ -225,12 +225,13 @@
         "qs_pg:id":1264026,
         "wd:id":"Q139179"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008834,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e3258fa62c9e92cb1b154ac9fc69c464",
+    "wof:geomhash":"063d5af94bf5b67b61c357720d340c90",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -240,7 +241,7 @@
         }
     ],
     "wof:id":421170045,
-    "wof:lastmodified":1690927775,
+    "wof:lastmodified":1695886115,
     "wof:name":"Zacapa",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/421/170/143/421170143.geojson
+++ b/data/421/170/143/421170143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004671,
-    "geom:area_square_m":55841684.035691,
+    "geom:area_square_m":55841925.726146,
     "geom:bbox":"-91.326009,14.738722,-91.229915,14.821973",
     "geom:latitude":14.77954,
     "geom:longitude":-91.275243,
@@ -115,12 +115,13 @@
         "qs_pg:id":220310,
         "wd:id":"Q2401971"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008839,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"374d696e709c6d3a3de8c5f9cd4dedfa",
+    "wof:geomhash":"eb8d5c68dc1f7573ffd3d63fd88bf867",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421170143,
-    "wof:lastmodified":1690927774,
+    "wof:lastmodified":1695886029,
     "wof:name":"Santa Lucia Utatlan",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/170/799/421170799.geojson
+++ b/data/421/170/799/421170799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012709,
-    "geom:area_square_m":151545710.158964,
+    "geom:area_square_m":151545790.260969,
     "geom:bbox":"-91.706753,15.253916,-91.531017,15.416356",
     "geom:latitude":15.339859,
     "geom:longitude":-91.626097,
@@ -153,12 +153,13 @@
         "wd:id":"Q2401903",
         "wk:page":"Santa B\u00e1rbara, Huehuetenango"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008869,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f485ed56e8e8254dbfc7978b875bcb00",
+    "wof:geomhash":"365bda59d6407f3ecaf2677a030864da",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421170799,
-    "wof:lastmodified":1690927771,
+    "wof:lastmodified":1695886115,
     "wof:name":"Santa Barbara",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/170/801/421170801.geojson
+++ b/data/421/170/801/421170801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003605,
-    "geom:area_square_m":43054995.119434,
+    "geom:area_square_m":43055069.413359,
     "geom:bbox":"-91.793852,14.990296,-91.698285,15.056423",
     "geom:latitude":15.02505,
     "geom:longitude":-91.744629,
@@ -171,12 +171,13 @@
         "wd:id":"Q845976",
         "wk:page":"San Lorenzo, San Marcos"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008869,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de367a055bf628d1e4b9bde8558ce4e2",
+    "wof:geomhash":"54eb88d337c207bc37437cf6e47222cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421170801,
-    "wof:lastmodified":1690927777,
+    "wof:lastmodified":1695886115,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/421/170/963/421170963.geojson
+++ b/data/421/170/963/421170963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004609,
-    "geom:area_square_m":55111955.875596,
+    "geom:area_square_m":55112188.443844,
     "geom:bbox":"-91.139643,14.690285,-91.072415,14.813876",
     "geom:latitude":14.746619,
     "geom:longitude":-91.10046,
@@ -121,12 +121,13 @@
         "qs_pg:id":1203849,
         "wd:id":"Q2402766"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008876,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61fdbdc6ac0dad90e37115790eae3f2d",
+    "wof:geomhash":"2b17f4136609559521e9a7458f407a6f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421170963,
-    "wof:lastmodified":1690927771,
+    "wof:lastmodified":1695886029,
     "wof:name":"San Andres Semetabaj",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/171/417/421171417.geojson
+++ b/data/421/171/417/421171417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065512,
-    "geom:area_square_m":785879702.077057,
+    "geom:area_square_m":785879902.622482,
     "geom:bbox":"-91.315468,13.913028,-90.967471,14.194081",
     "geom:latitude":14.03828,
     "geom:longitude":-91.124216,
@@ -235,12 +235,13 @@
         "qs_pg:id":1263961,
         "wd:id":"Q2608473"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008893,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"34a83cf65b97a81468e04375a64910b7",
+    "wof:geomhash":"8270a9eaf25b2a5dd8e0fada1fbda056",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -250,7 +251,7 @@
         }
     ],
     "wof:id":421171417,
-    "wof:lastmodified":1690927826,
+    "wof:lastmodified":1695886031,
     "wof:name":"La Gomera",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/171/421/421171421.geojson
+++ b/data/421/171/421/421171421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018641,
-    "geom:area_square_m":222325803.131968,
+    "geom:area_square_m":222326160.576947,
     "geom:bbox":"-90.207258,15.257473,-89.920079,15.356265",
     "geom:latitude":15.302076,
     "geom:longitude":-90.08131,
@@ -127,12 +127,13 @@
         "qs_pg:id":1263963,
         "wd:id":"Q391295"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008893,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d40956141592b81c1ed0a1fcfdc527a6",
+    "wof:geomhash":"71a489ee4de2f5beefb14d915c2c299f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421171421,
-    "wof:lastmodified":1690927826,
+    "wof:lastmodified":1695886031,
     "wof:name":"Tucuru",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/171/679/421171679.geojson
+++ b/data/421/171/679/421171679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008108,
-    "geom:area_square_m":96999322.516016,
+    "geom:area_square_m":96999039.863113,
     "geom:bbox":"-90.643343,14.569655,-90.516887,14.714834",
     "geom:latitude":14.641785,
     "geom:longitude":-90.584847,
@@ -226,12 +226,13 @@
         "qs_pg:id":1263978,
         "wd:id":"Q948953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008902,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa4488f9653ceac794b4a405404cc278",
+    "wof:geomhash":"c4572eaf074e4be3ccba062047d6df3d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -241,7 +242,7 @@
         }
     ],
     "wof:id":421171679,
-    "wof:lastmodified":1690927827,
+    "wof:lastmodified":1695886031,
     "wof:name":"Mixco",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/171/681/421171681.geojson
+++ b/data/421/171/681/421171681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.181902,
-    "geom:area_square_m":2147168508.97346,
+    "geom:area_square_m":2147168023.750003,
     "geom:bbox":"-89.345014,16.813504,-89.150078,17.814063",
     "geom:latitude":17.326587,
     "geom:longitude":-89.244356,
@@ -130,12 +130,13 @@
         "qs_pg:id":1263979,
         "wd:id":"Q599455"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008902,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"792518deae7ef9642b197d97a2968956",
+    "wof:geomhash":"d3ca220ac656f7b7c7426be861759b46",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421171681,
-    "wof:lastmodified":1690927823,
+    "wof:lastmodified":1695886031,
     "wof:name":"Melchor De Mencos",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/171/683/421171683.geojson
+++ b/data/421/171/683/421171683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.211475,
-    "geom:area_square_m":2506844231.145222,
+    "geom:area_square_m":2506844673.176418,
     "geom:bbox":"-90.080734,16.208801,-89.166095,16.917019",
     "geom:latitude":16.530597,
     "geom:longitude":-89.507053,
@@ -130,12 +130,13 @@
         "qs_pg:id":1263980,
         "wd:id":"Q989812"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f61d01aaf60c05207bf9aaf5b152ccf8",
+    "wof:geomhash":"1ce9ed5dbff8166c0683ab5abb5cf813",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421171683,
-    "wof:lastmodified":1690927828,
+    "wof:lastmodified":1695886115,
     "wof:name":"Dolores",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/171/685/421171685.geojson
+++ b/data/421/171/685/421171685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010623,
-    "geom:area_square_m":126991316.590067,
+    "geom:area_square_m":126991713.952462,
     "geom:bbox":"-91.588326,14.736924,-91.458417,14.88609",
     "geom:latitude":14.815318,
     "geom:longitude":-91.533158,
@@ -276,12 +276,13 @@
         "qs_pg:id":1263990,
         "wd:id":"Q334577"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8d8819a1070efb23787c11392c187088",
+    "wof:geomhash":"ec029432c3670ce2c1a8c9554188dc48",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -291,7 +292,7 @@
         }
     ],
     "wof:id":421171685,
-    "wof:lastmodified":1690927827,
+    "wof:lastmodified":1695886031,
     "wof:name":"Quetzaltenango",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/171/687/421171687.geojson
+++ b/data/421/171/687/421171687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020691,
-    "geom:area_square_m":247251615.328408,
+    "geom:area_square_m":247251430.460913,
     "geom:bbox":"-91.212199,14.779427,-91.008815,14.99428",
     "geom:latitude":14.896669,
     "geom:longitude":-91.092126,
@@ -157,12 +157,13 @@
         "qs_pg:id":1264009,
         "wd:id":"Q603423"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"343b911ad8bb97d78c4eb95604402ddd",
+    "wof:geomhash":"539a3524a203a5e0e4d093497aa80196",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":421171687,
-    "wof:lastmodified":1690927824,
+    "wof:lastmodified":1695886031,
     "wof:name":"Chichicastenango",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/171/689/421171689.geojson
+++ b/data/421/171/689/421171689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008115,
-    "geom:area_square_m":97120708.510385,
+    "geom:area_square_m":97120752.52539,
     "geom:bbox":"-91.804713,14.500989,-91.71292,14.671689",
     "geom:latitude":14.568348,
     "geom:longitude":-91.749764,
@@ -118,12 +118,13 @@
         "qs_pg:id":1264011,
         "wd:id":"Q2402509"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f71bb277cb8263a78435682484a65dad",
+    "wof:geomhash":"8c90e39ffe918b0d922b14c7f7371893",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421171689,
-    "wof:lastmodified":1690927824,
+    "wof:lastmodified":1695886031,
     "wof:name":"El Asintal",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/421/171/693/421171693.geojson
+++ b/data/421/171/693/421171693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002968,
-    "geom:area_square_m":35528375.390796,
+    "geom:area_square_m":35528278.916202,
     "geom:bbox":"-90.818989,14.464179,-90.743479,14.547418",
     "geom:latitude":14.507918,
     "geom:longitude":-90.771626,
@@ -133,12 +133,13 @@
         "qs_pg:id":1264014,
         "wd:id":"Q2445843"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9ad0f8a8fd70824202c1851decf26a7",
+    "wof:geomhash":"ab58976ca517804cf796a4ad0cf82ccc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421171693,
-    "wof:lastmodified":1690927825,
+    "wof:lastmodified":1695886031,
     "wof:name":"Ciudad Vieja",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/171/697/421171697.geojson
+++ b/data/421/171/697/421171697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003203,
-    "geom:area_square_m":38317748.542967,
+    "geom:area_square_m":38317705.970948,
     "geom:bbox":"-91.355988,14.629086,-91.278609,14.710311",
     "geom:latitude":14.666464,
     "geom:longitude":-91.314279,
@@ -124,12 +124,13 @@
         "qs_pg:id":1264024,
         "wd:id":"Q2403501"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"031a7c1fa3d16cfb1e513474f99b8227",
+    "wof:geomhash":"86acdb8140787d8db53c70296c5d2656",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421171697,
-    "wof:lastmodified":1690927828,
+    "wof:lastmodified":1695886031,
     "wof:name":"San Juan La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/171/915/421171915.geojson
+++ b/data/421/171/915/421171915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004511,
-    "geom:area_square_m":53960946.238096,
+    "geom:area_square_m":53961129.632066,
     "geom:bbox":"-90.921769,14.620602,-90.810735,14.736256",
     "geom:latitude":14.68104,
     "geom:longitude":-90.874772,
@@ -117,12 +117,13 @@
         "qs_pg:id":273382,
         "wd:id":"Q1572856"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008911,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"084ec784d068471ab2bcc3db1dca2f04",
+    "wof:geomhash":"a31bf1b40ee621157c317f4d5d1c67fa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421171915,
-    "wof:lastmodified":1690927825,
+    "wof:lastmodified":1695886031,
     "wof:name":"Zaragoza",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/172/213/421172213.geojson
+++ b/data/421/172/213/421172213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024588,
-    "geom:area_square_m":294835197.811595,
+    "geom:area_square_m":294835228.156604,
     "geom:bbox":"-91.016025,13.961814,-90.884757,14.279828",
     "geom:latitude":14.132082,
     "geom:longitude":-90.950079,
@@ -126,12 +126,13 @@
         "wd:id":"Q129369",
         "wk:page":"La Democracia, Escuintla"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008927,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5454f017fa18b3e11f622d79a4717913",
+    "wof:geomhash":"f388ae6f9f5d6786954024693d362544",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421172213,
-    "wof:lastmodified":1690927715,
+    "wof:lastmodified":1695886027,
     "wof:name":"La Democracia",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/172/513/421172513.geojson
+++ b/data/421/172/513/421172513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003938,
-    "geom:area_square_m":47107410.803757,
+    "geom:area_square_m":47107467.280745,
     "geom:bbox":"-90.870255,14.627997,-90.772655,14.7443",
     "geom:latitude":14.683236,
     "geom:longitude":-90.824937,
@@ -187,12 +187,13 @@
         "qs_pg:id":1313047,
         "wd:id":"Q1002552"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bf718a48d2dde067ce8ec6bbbae4117b",
+    "wof:geomhash":"83a129feacda89d8c73092fc77a17254",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":421172513,
-    "wof:lastmodified":1690927716,
+    "wof:lastmodified":1695886114,
     "wof:name":"Chimaltenango",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/172/515/421172515.geojson
+++ b/data/421/172/515/421172515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001113,
-    "geom:area_square_m":13309078.333466,
+    "geom:area_square_m":13308997.775378,
     "geom:bbox":"-91.323624,14.691728,-91.284745,14.745204",
     "geom:latitude":14.72081,
     "geom:longitude":-91.303077,
@@ -118,12 +118,13 @@
         "qs_pg:id":1313048,
         "wd:id":"Q2401885"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6659a19e44d404af6626830e71df8f77",
+    "wof:geomhash":"d5d934e8d69331ed1713bacf00483048",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421172515,
-    "wof:lastmodified":1690927717,
+    "wof:lastmodified":1695886027,
     "wof:name":"Santa Clara La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/172/617/421172617.geojson
+++ b/data/421/172/617/421172617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026499,
-    "geom:area_square_m":316330219.968719,
+    "geom:area_square_m":316330462.300625,
     "geom:bbox":"-90.589185,14.99382,-90.415223,15.266874",
     "geom:latitude":15.11297,
     "geom:longitude":-90.506019,
@@ -136,12 +136,13 @@
         "qs_pg:id":1314840,
         "wd:id":"Q1246149"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d1f7c30a224952ce9740c3e720f5e6f",
+    "wof:geomhash":"76746ae8be1f244c6cc2db36270f1013",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":421172617,
-    "wof:lastmodified":1690927712,
+    "wof:lastmodified":1695886027,
     "wof:name":"Rabinal",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/421/172/619/421172619.geojson
+++ b/data/421/172/619/421172619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020836,
-    "geom:area_square_m":249088797.572509,
+    "geom:area_square_m":249089078.795022,
     "geom:bbox":"-91.085765,14.683876,-90.929397,14.937722",
     "geom:latitude":14.802653,
     "geom:longitude":-91.005182,
@@ -130,12 +130,13 @@
         "qs_pg:id":1314841,
         "wd:id":"Q2400650"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008949,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"82c1043da377fc3b9465bae12381986e",
+    "wof:geomhash":"39db5fb2515062f67bccfa8abf3d6486",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421172619,
-    "wof:lastmodified":1690927713,
+    "wof:lastmodified":1695886027,
     "wof:name":"Tecpan Guatemala",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/172/621/421172621.geojson
+++ b/data/421/172/621/421172621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012676,
-    "geom:area_square_m":151867590.513217,
+    "geom:area_square_m":151867629.273477,
     "geom:bbox":"-90.713291,14.248745,-90.592535,14.429007",
     "geom:latitude":14.33376,
     "geom:longitude":-90.645354,
@@ -115,12 +115,13 @@
         "qs_pg:id":1314842,
         "wd:id":"Q1748582"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008949,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"884be59aea884ea10af30578a1d66c84",
+    "wof:geomhash":"88e316b34d331dd189362362a0b32165",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421172621,
-    "wof:lastmodified":1690927712,
+    "wof:lastmodified":1695886027,
     "wof:name":"San Vicente Pacaya",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/172/645/421172645.geojson
+++ b/data/421/172/645/421172645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006261,
-    "geom:area_square_m":74791594.272889,
+    "geom:area_square_m":74791574.676476,
     "geom:bbox":"-91.545284,14.919982,-91.405468,15.020969",
     "geom:latitude":14.969846,
     "geom:longitude":-91.477217,
@@ -115,12 +115,13 @@
         "qs_pg:id":1315333,
         "wd:id":"Q2608408"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008950,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e28f56a81b1e05f8506594993e5e3af7",
+    "wof:geomhash":"a0eee82982f4242d27fd570f68510dfc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421172645,
-    "wof:lastmodified":1690927713,
+    "wof:lastmodified":1695886027,
     "wof:name":"San Francisco El Alto",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/172/665/421172665.geojson
+++ b/data/421/172/665/421172665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01746,
-    "geom:area_square_m":208816898.344554,
+    "geom:area_square_m":208817121.90818,
     "geom:bbox":"-91.829373,14.560269,-91.667516,14.835513",
     "geom:latitude":14.707055,
     "geom:longitude":-91.754716,
@@ -129,12 +129,13 @@
         "qs_pg:id":1316064,
         "wd:id":"Q2426806"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459008950,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05695436687b76aebe308283b037430f",
+    "wof:geomhash":"753d62f42d82792d0f76a1366849805b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421172665,
-    "wof:lastmodified":1690927716,
+    "wof:lastmodified":1695886027,
     "wof:name":"Colomba",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/173/721/421173721.geojson
+++ b/data/421/173/721/421173721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006153,
-    "geom:area_square_m":73321021.201374,
+    "geom:area_square_m":73321301.175753,
     "geom:bbox":"-91.668684,15.410896,-91.576026,15.541585",
     "geom:latitude":15.474229,
     "geom:longitude":-91.625213,
@@ -120,12 +120,13 @@
         "wd:id":"Q531288",
         "wk:page":"San Juan Atit\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009000,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5743edea76ed208e2744a2f68d7c67aa",
+    "wof:geomhash":"a1c452b5b23af077a81c0ddcc683e8f4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421173721,
-    "wof:lastmodified":1690927705,
+    "wof:lastmodified":1695886026,
     "wof:name":"San Juan Atitan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/173/723/421173723.geojson
+++ b/data/421/173/723/421173723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001068,
-    "geom:area_square_m":12763990.427272,
+    "geom:area_square_m":12763823.616678,
     "geom:bbox":"-91.598191,14.856388,-91.554465,14.90007",
     "geom:latitude":14.878278,
     "geom:longitude":-91.575929,
@@ -129,12 +129,13 @@
         "wd:id":"Q2608447",
         "wk:page":"La Esperanza, Quetzaltenango"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009004,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b8901163efec304b46904294f24abe22",
+    "wof:geomhash":"f4523ff20f66c265ccd119f8f506348f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421173723,
-    "wof:lastmodified":1690927702,
+    "wof:lastmodified":1695886114,
     "wof:name":"La Esperanza",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/175/387/421175387.geojson
+++ b/data/421/175/387/421175387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000556,
-    "geom:area_square_m":6648723.99589,
+    "geom:area_square_m":6648734.504761,
     "geom:bbox":"-91.166278,14.730673,-91.137142,14.759366",
     "geom:latitude":14.744632,
     "geom:longitude":-91.149599,
@@ -144,12 +144,13 @@
         "qs_pg:id":368919,
         "wd:id":"Q1634223"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bfb303ad4615661dd125afcb96340640",
+    "wof:geomhash":"a369e12d1fab3c653977d4b8671fd033",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":421175387,
-    "wof:lastmodified":1690927725,
+    "wof:lastmodified":1695886027,
     "wof:name":"Panajachel",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/175/573/421175573.geojson
+++ b/data/421/175/573/421175573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056094,
-    "geom:area_square_m":669754348.117131,
+    "geom:area_square_m":669754236.152407,
     "geom:bbox":"-90.456237,14.871926,-90.014921,15.23407",
     "geom:latitude":15.069352,
     "geom:longitude":-90.286863,
@@ -175,12 +175,13 @@
         "qs_pg:id":993370,
         "wd:id":"Q1023655"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009072,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be488a03bc67e14654e0310aed3715ff",
+    "wof:geomhash":"8421cc531362ccd463fc1854f519baea",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":421175573,
-    "wof:lastmodified":1690927724,
+    "wof:lastmodified":1695886027,
     "wof:name":"Salama",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/421/175/579/421175579.geojson
+++ b/data/421/175/579/421175579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007123,
-    "geom:area_square_m":85171369.605003,
+    "geom:area_square_m":85170999.208143,
     "geom:bbox":"-90.943546,14.693578,-90.847775,14.81289",
     "geom:latitude":14.74835,
     "geom:longitude":-90.897531,
@@ -123,12 +123,13 @@
         "wd:id":"Q1254234",
         "wk:page":"San Juan Comalapa"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009072,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"47332c2fc68eef0f8ba1c5d3320cacc6",
+    "wof:geomhash":"13e185d3842764f566de6b5d2e683d16",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421175579,
-    "wof:lastmodified":1690927725,
+    "wof:lastmodified":1695886027,
     "wof:name":"Comalapa",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/177/237/421177237.geojson
+++ b/data/421/177/237/421177237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003358,
-    "geom:area_square_m":40176237.677583,
+    "geom:area_square_m":40176224.853827,
     "geom:bbox":"-90.807002,14.560361,-90.731887,14.643646",
     "geom:latitude":14.597722,
     "geom:longitude":-90.770989,
@@ -133,12 +133,13 @@
         "qs_pg:id":1119670,
         "wd:id":"Q2644237"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c8c13bd35aeb60ebc67dc7fb1ed82f02",
+    "wof:geomhash":"6679f7d8fc9dccefc32643f8cc7738a7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421177237,
-    "wof:lastmodified":1690927782,
+    "wof:lastmodified":1695886030,
     "wof:name":"Pastores",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/177/381/421177381.geojson
+++ b/data/421/177/381/421177381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020955,
-    "geom:area_square_m":250499461.409321,
+    "geom:area_square_m":250499215.958323,
     "geom:bbox":"-89.50069,14.718378,-89.214754,14.90658",
     "geom:latitude":14.811539,
     "geom:longitude":-89.376796,
@@ -117,12 +117,13 @@
         "wd:id":"Q1954342",
         "wk:page":"Jocot\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009142,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7788bd73d06740c6363e20b731301d5b",
+    "wof:geomhash":"7b711c78ba4fb1b027f9b2406114c4b6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421177381,
-    "wof:lastmodified":1690927784,
+    "wof:lastmodified":1695886030,
     "wof:name":"Jocotan",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/178/135/421178135.geojson
+++ b/data/421/178/135/421178135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014103,
-    "geom:area_square_m":167841987.674276,
+    "geom:area_square_m":167842166.410582,
     "geom:bbox":"-91.875842,15.660385,-91.630394,15.840153",
     "geom:latitude":15.752442,
     "geom:longitude":-91.731563,
@@ -130,12 +130,13 @@
         "qs_pg:id":44031,
         "wd:id":"Q1124580"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009171,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f43a2f761e633e5cd429bda1b9119afb",
+    "wof:geomhash":"c65e12110aa702d0190f6ea7c5112d4a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421178135,
-    "wof:lastmodified":1690927809,
+    "wof:lastmodified":1695886031,
     "wof:name":"Jacaltenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/178/323/421178323.geojson
+++ b/data/421/178/323/421178323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001403,
-    "geom:area_square_m":16779306.163779,
+    "geom:area_square_m":16779155.761763,
     "geom:bbox":"-91.158312,14.758249,-91.106421,14.809143",
     "geom:latitude":14.781245,
     "geom:longitude":-91.134591,
@@ -118,12 +118,13 @@
         "qs_pg:id":61139,
         "wd:id":"Q1748599"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009178,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"87e0d8f12acfe6e7bfcff1894968a5f4",
+    "wof:geomhash":"83b757c2d8f419b73916b1df68c0da0c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421178323,
-    "wof:lastmodified":1690927811,
+    "wof:lastmodified":1695886032,
     "wof:name":"Concepcion",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/178/903/421178903.geojson
+++ b/data/421/178/903/421178903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015234,
-    "geom:area_square_m":182247138.051608,
+    "geom:area_square_m":182247074.490321,
     "geom:bbox":"-91.114255,14.579361,-90.950654,14.730192",
     "geom:latitude":14.646108,
     "geom:longitude":-91.033089,
@@ -123,12 +123,13 @@
         "qs_pg:id":288295,
         "wd:id":"Q2574268"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009197,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de6038c8ac3bd7acf28ac1e776de9ed6",
+    "wof:geomhash":"f0080723caa9e9a8065c65b6b5e147d7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421178903,
-    "wof:lastmodified":1690927812,
+    "wof:lastmodified":1695886032,
     "wof:name":"Patzun",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/178/905/421178905.geojson
+++ b/data/421/178/905/421178905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001972,
-    "geom:area_square_m":23609731.283214,
+    "geom:area_square_m":23609793.682228,
     "geom:bbox":"-90.581726,14.472167,-90.531764,14.545521",
     "geom:latitude":14.509277,
     "geom:longitude":-90.554064,
@@ -89,12 +89,13 @@
         "hasc:id":"GT.GU.MP",
         "qs_pg:id":288296
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009197,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eb6f10a98409634a18d8d7a68eb44334",
+    "wof:geomhash":"aac992fd817a91e39a246cb532535f2d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421178905,
-    "wof:lastmodified":1627522160,
+    "wof:lastmodified":1695886628,
     "wof:name":"Petapa",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/178/907/421178907.geojson
+++ b/data/421/178/907/421178907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018091,
-    "geom:area_square_m":216223243.383795,
+    "geom:area_square_m":216223202.554504,
     "geom:bbox":"-90.178511,14.785948,-89.931314,14.921496",
     "geom:latitude":14.851285,
     "geom:longitude":-90.06255,
@@ -156,12 +156,13 @@
         "qs_pg:id":288297,
         "wd:id":"Q615633"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009197,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"507a59511a08704ce7725af8d016323a",
+    "wof:geomhash":"0e44197c7d1c75a33bce09682cc7d559",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":421178907,
-    "wof:lastmodified":1690927810,
+    "wof:lastmodified":1695886032,
     "wof:name":"Guastatoya",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/421/178/909/421178909.geojson
+++ b/data/421/178/909/421178909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043987,
-    "geom:area_square_m":527474367.096601,
+    "geom:area_square_m":527474065.194457,
     "geom:bbox":"-91.434632,13.952911,-91.169872,14.307749",
     "geom:latitude":14.121722,
     "geom:longitude":-91.300859,
@@ -127,12 +127,13 @@
         "qs_pg:id":288298,
         "wd:id":"Q317414"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009197,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a9a18708778779aa6afcd3bef7677439",
+    "wof:geomhash":"d06c2e9ed13760a24a59c9566f3ef4fd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421178909,
-    "wof:lastmodified":1690927809,
+    "wof:lastmodified":1695886032,
     "wof:name":"Nueva Concepcion",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/179/171/421179171.geojson
+++ b/data/421/179/171/421179171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161533,
-    "geom:area_square_m":1913807838.620262,
+    "geom:area_square_m":1913807524.649647,
     "geom:bbox":"-90.248424,16.33706,-89.601709,16.912896",
     "geom:latitude":16.633687,
     "geom:longitude":-89.944251,
@@ -153,12 +153,13 @@
         "wd:id":"Q796492",
         "wk:page":"San Francisco, El Pet\u00e9n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009206,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"317be39e8b708abfb4d176ab052c1db7",
+    "wof:geomhash":"93301c9a52e93703236bce2a665cb70c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421179171,
-    "wof:lastmodified":1690927808,
+    "wof:lastmodified":1695886115,
     "wof:name":"San Francisco",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/179/197/421179197.geojson
+++ b/data/421/179/197/421179197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005497,
-    "geom:area_square_m":65760216.038313,
+    "geom:area_square_m":65759877.336528,
     "geom:bbox":"-90.997693,14.574905,-90.89623,14.693318",
     "geom:latitude":14.637048,
     "geom:longitude":-90.941385,
@@ -120,12 +120,13 @@
         "wd:id":"Q1523943",
         "wk:page":"Patzic\u00eda"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009207,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"71ca1d7e9d9e934a3a2fed9dfbc16a65",
+    "wof:geomhash":"c44356f353d513cb03b9c262ad690950",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421179197,
-    "wof:lastmodified":1690927800,
+    "wof:lastmodified":1695886030,
     "wof:name":"Patzicia",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/181/909/421181909.geojson
+++ b/data/421/181/909/421181909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015907,
-    "geom:area_square_m":189646069.23554,
+    "geom:area_square_m":189645844.021701,
     "geom:bbox":"-90.350961,15.329348,-90.110953,15.45648",
     "geom:latitude":15.389016,
     "geom:longitude":-90.237306,
@@ -124,12 +124,13 @@
         "qs_pg:id":510772,
         "wd:id":"Q325793"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009312,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be421dc105679a2239fbe7a9a664f0d0",
+    "wof:geomhash":"f7937855d4c97d4b88473be40fcf4b1b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421181909,
-    "wof:lastmodified":1690927721,
+    "wof:lastmodified":1695886027,
     "wof:name":"San Juan Chamelco",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/182/335/421182335.geojson
+++ b/data/421/182/335/421182335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019764,
-    "geom:area_square_m":235423122.353891,
+    "geom:area_square_m":235423035.873694,
     "geom:bbox":"-90.072584,15.488876,-89.906449,15.668428",
     "geom:latitude":15.567683,
     "geom:longitude":-89.988798,
@@ -89,12 +89,13 @@
         "hasc:id":"GT.AV.LA",
         "qs_pg:id":900269
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009326,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46f95b3b95eadd65b6d3252442ab6ea8",
+    "wof:geomhash":"1ffba0fa7dcf951452d34627ead3a711",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421182335,
-    "wof:lastmodified":1627522160,
+    "wof:lastmodified":1695886628,
     "wof:name":"Lanquin",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/182/337/421182337.geojson
+++ b/data/421/182/337/421182337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007611,
-    "geom:area_square_m":91095886.3906,
+    "geom:area_square_m":91095829.431349,
     "geom:bbox":"-90.667854,14.473247,-90.548883,14.585847",
     "geom:latitude":14.538327,
     "geom:longitude":-90.607044,
@@ -229,12 +229,13 @@
         "qs_pg:id":900270,
         "wd:id":"Q1018584"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009326,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"44dd34744b6b9de71c6b3246feeda42c",
+    "wof:geomhash":"112f466176b85369759b34a7e8e229a2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -244,7 +245,7 @@
         }
     ],
     "wof:id":421182337,
-    "wof:lastmodified":1690927812,
+    "wof:lastmodified":1695886032,
     "wof:name":"Villa Nueva",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/182/433/421182433.geojson
+++ b/data/421/182/433/421182433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038228,
-    "geom:area_square_m":456378766.591786,
+    "geom:area_square_m":456378541.523671,
     "geom:bbox":"-89.757775,14.987376,-89.438146,15.196651",
     "geom:latitude":15.098303,
     "geom:longitude":-89.600178,
@@ -118,12 +118,13 @@
         "qs_pg:id":911522,
         "wd:id":"Q593520"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009329,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0e5d22ed7272613968f4775f5fbf01b0",
+    "wof:geomhash":"2e6cd616405ad01ec0724bb3c542ba05",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421182433,
-    "wof:lastmodified":1690927818,
+    "wof:lastmodified":1695886032,
     "wof:name":"Rio Hondo",
     "wof:parent_id":85671727,
     "wof:placetype":"county",

--- a/data/421/182/715/421182715.geojson
+++ b/data/421/182/715/421182715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.260113,
-    "geom:area_square_m":3090206197.671587,
+    "geom:area_square_m":3090206146.918968,
     "geom:bbox":"-90.076964,15.847581,-89.203134,16.272541",
     "geom:latitude":16.099718,
     "geom:longitude":-89.605195,
@@ -166,12 +166,13 @@
         "qs_pg:id":985859,
         "wd:id":"Q1020572"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009339,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e490b563fcf05a6ec4dae72a951b83ff",
+    "wof:geomhash":"3403d5cf5dcbbd51a2f7953fb809589b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":421182715,
-    "wof:lastmodified":1690927814,
+    "wof:lastmodified":1695886115,
     "wof:name":"San Luis",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/182/831/421182831.geojson
+++ b/data/421/182/831/421182831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064072,
-    "geom:area_square_m":763053472.693399,
+    "geom:area_square_m":763053472.693306,
     "geom:bbox":"-89.9503342287,15.4850053128,-89.5346526406,15.7293115842",
     "geom:latitude":15.605821,
     "geom:longitude":-89.77188,
@@ -111,12 +111,13 @@
         "hasc:id":"GT.QZ.CJ",
         "qs_pg:id":772654
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009348,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"885b2886dd66c5ed61b70403e092ebab",
+    "wof:geomhash":"05263769621b8b3490545d390429cbf6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421182831,
-    "wof:lastmodified":1582360597,
+    "wof:lastmodified":1695886032,
     "wof:name":"Cahabon",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/182/885/421182885.geojson
+++ b/data/421/182/885/421182885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001691,
-    "geom:area_square_m":20222132.511528,
+    "geom:area_square_m":20222065.460384,
     "geom:bbox":"-90.962222,14.667419,-90.904642,14.722942",
     "geom:latitude":14.695196,
     "geom:longitude":-90.933556,
@@ -120,12 +120,13 @@
         "wd:id":"Q1523955",
         "wk:page":"Santa Cruz Balany\u00e1"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ddfb53043ace6f3f7efc07471ad33130",
+    "wof:geomhash":"f3648b87b7b3690287931c30d5b263eb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182885,
-    "wof:lastmodified":1690927816,
+    "wof:lastmodified":1695886032,
     "wof:name":"Santa Cruz Balanya",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/183/137/421183137.geojson
+++ b/data/421/183/137/421183137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057346,
-    "geom:area_square_m":686095630.291578,
+    "geom:area_square_m":686095407.55212,
     "geom:bbox":"-90.192341,14.427744,-89.921633,14.821568",
     "geom:latitude":14.630533,
     "geom:longitude":-90.032355,
@@ -199,12 +199,13 @@
         "qs_pg:id":963179,
         "wd:id":"Q1023359"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009359,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8d255adff8d8317a452112dd6caafdb",
+    "wof:geomhash":"213eb84fd4d9f1595177376819dced8f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":421183137,
-    "wof:lastmodified":1690927785,
+    "wof:lastmodified":1695886115,
     "wof:name":"Jalapa",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/421/183/939/421183939.geojson
+++ b/data/421/183/939/421183939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001483,
-    "geom:area_square_m":17732120.186888,
+    "geom:area_square_m":17732031.011879,
     "geom:bbox":"-91.247736,14.748416,-91.200341,14.804347",
     "geom:latitude":14.77242,
     "geom:longitude":-91.226107,
@@ -118,12 +118,13 @@
         "qs_pg:id":986271,
         "wd:id":"Q2401917"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009395,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7ccdfe121676f7ba90e767e6e1cf522d",
+    "wof:geomhash":"03f6bc3d21fd37f48641f1d27525b9e0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421183939,
-    "wof:lastmodified":1690927785,
+    "wof:lastmodified":1695886030,
     "wof:name":"San Jose Chacaya",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/184/389/421184389.geojson
+++ b/data/421/184/389/421184389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111764,
-    "geom:area_square_m":1331202484.045657,
+    "geom:area_square_m":1331201979.716276,
     "geom:bbox":"-90.367409,15.37652,-89.93183,15.775525",
     "geom:latitude":15.57946,
     "geom:longitude":-90.153023,
@@ -127,12 +127,13 @@
         "qs_pg:id":995766,
         "wd:id":"Q325586"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de8362d566ec8ad379e88fda5d809f15",
+    "wof:geomhash":"b5f5e79f1c1b0f9021cda8c4f9cd2c37",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421184389,
-    "wof:lastmodified":1690927769,
+    "wof:lastmodified":1695886030,
     "wof:name":"San Pedro Carcha",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/184/391/421184391.geojson
+++ b/data/421/184/391/421184391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031899,
-    "geom:area_square_m":380278859.541832,
+    "geom:area_square_m":380279169.423135,
     "geom:bbox":"-90.718535,15.283575,-90.428209,15.490547",
     "geom:latitude":15.39677,
     "geom:longitude":-90.565266,
@@ -135,12 +135,13 @@
         "qs_pg:id":995767,
         "wd:id":"Q284529"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0fbcf27a6c2177729db11d47a8a0c95",
+    "wof:geomhash":"45cbcb16a93cdd3b084cc289031b61de",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421184391,
-    "wof:lastmodified":1690927765,
+    "wof:lastmodified":1695886030,
     "wof:name":"San Cristobal Verapaz",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/184/393/421184393.geojson
+++ b/data/421/184/393/421184393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018029,
-    "geom:area_square_m":215413209.754944,
+    "geom:area_square_m":215412941.321575,
     "geom:bbox":"-92.184161,14.798161,-92.029992,15.033978",
     "geom:latitude":14.918702,
     "geom:longitude":-92.106364,
@@ -127,12 +127,13 @@
         "qs_pg:id":995768,
         "wd:id":"Q2402136"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"606b0ed6bbcdb6f991ea1642f6f28b2f",
+    "wof:geomhash":"a8b1c349f0d7c411fc998870f8398f7a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421184393,
-    "wof:lastmodified":1690927769,
+    "wof:lastmodified":1695886030,
     "wof:name":"Malacatan",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/421/184/395/421184395.geojson
+++ b/data/421/184/395/421184395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008428,
-    "geom:area_square_m":100575715.952131,
+    "geom:area_square_m":100575715.952102,
     "geom:bbox":"-90.9190368526,15.1433597168,-90.8061702576,15.256368827",
     "geom:latitude":15.195116,
     "geom:longitude":-90.862824,
@@ -128,12 +128,13 @@
         "qs_pg:id":995769,
         "wd:id":"Q450721"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9863d16fd9dd5bd64b96a21085d73dc7",
+    "wof:geomhash":"1b8ce14fb9538097fde72afd224636a3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421184395,
-    "wof:lastmodified":1582360596,
+    "wof:lastmodified":1695886030,
     "wof:name":"Canilla",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/184/397/421184397.geojson
+++ b/data/421/184/397/421184397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015238,
-    "geom:area_square_m":182202014.264482,
+    "geom:area_square_m":182202386.572452,
     "geom:bbox":"-91.504305,14.593427,-91.242551,14.877921",
     "geom:latitude":14.760578,
     "geom:longitude":-91.390807,
@@ -117,12 +117,13 @@
         "qs_pg:id":995770,
         "wd:id":"Q2717990"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9285ff42c3b8b5bef48441d3c57f3cef",
+    "wof:geomhash":"f6c776ef2c25c25836d16a440fd429aa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421184397,
-    "wof:lastmodified":1690927766,
+    "wof:lastmodified":1695886030,
     "wof:name":"Nahuala",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/184/399/421184399.geojson
+++ b/data/421/184/399/421184399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000982,
-    "geom:area_square_m":11751103.704125,
+    "geom:area_square_m":11751091.111868,
     "geom:bbox":"-90.829677,14.539654,-90.775719,14.572881",
     "geom:latitude":14.554208,
     "geom:longitude":-90.803872,
@@ -121,12 +121,13 @@
         "qs_pg:id":995772,
         "wd:id":"Q2400778"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e0b01e2c371b963287c9e7d2c4486be",
+    "wof:geomhash":"056f8a56f089cf44a2555a6a62c01c41",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421184399,
-    "wof:lastmodified":1690927766,
+    "wof:lastmodified":1695886030,
     "wof:name":"Santa Catarina Barahona",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/184/605/421184605.geojson
+++ b/data/421/184/605/421184605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001344,
-    "geom:area_square_m":16055436.925171,
+    "geom:area_square_m":16055393.633589,
     "geom:bbox":"-91.518784,14.882991,-91.475175,14.936365",
     "geom:latitude":14.909662,
     "geom:longitude":-91.496526,
@@ -121,12 +121,13 @@
         "qs_pg:id":1002234,
         "wd:id":"Q2609261"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009416,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8b438112eb2346af92040ece844d5c4e",
+    "wof:geomhash":"907fb93280840f8eab8acffaa000340e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421184605,
-    "wof:lastmodified":1690927767,
+    "wof:lastmodified":1695886030,
     "wof:name":"San Andres Xecul",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/184/713/421184713.geojson
+++ b/data/421/184/713/421184713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035727,
-    "geom:area_square_m":426683191.180081,
+    "geom:area_square_m":426683194.409368,
     "geom:bbox":"-90.091532,14.880185,-89.861059,15.154797",
     "geom:latitude":15.020229,
     "geom:longitude":-89.9854,
@@ -121,12 +121,13 @@
         "qs_pg:id":1003285,
         "wd:id":"Q1020409"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009419,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ba85c5dbe0ddb6fcd34d6379bb5c60f2",
+    "wof:geomhash":"f93a99d68bc07f400fae9dd134a3d50a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421184713,
-    "wof:lastmodified":1690927767,
+    "wof:lastmodified":1695886030,
     "wof:name":"San Agustin Acasaguastlan",
     "wof:parent_id":85671701,
     "wof:placetype":"county",

--- a/data/421/184/715/421184715.geojson
+++ b/data/421/184/715/421184715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037472,
-    "geom:area_square_m":449022063.851207,
+    "geom:area_square_m":449022300.689602,
     "geom:bbox":"-91.179381,14.146521,-90.979421,14.432341",
     "geom:latitude":14.286483,
     "geom:longitude":-91.070771,
@@ -130,12 +130,13 @@
         "qs_pg:id":1003286,
         "wd:id":"Q404550"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009420,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7258adacf8f0016537955cf038082a3d",
+    "wof:geomhash":"a56f1e7e22c2ec4ee18f0b827d345432",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421184715,
-    "wof:lastmodified":1690927768,
+    "wof:lastmodified":1695886030,
     "wof:name":"Santa Lucia Cotzumalguapa",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/184/717/421184717.geojson
+++ b/data/421/184/717/421184717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010466,
-    "geom:area_square_m":125131229.887586,
+    "geom:area_square_m":125130979.760548,
     "geom:bbox":"-90.620317,14.711041,-90.505461,14.888669",
     "geom:latitude":14.783767,
     "geom:longitude":-90.558431,
@@ -133,12 +133,13 @@
         "qs_pg:id":1003287,
         "wd:id":"Q275800"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009420,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee38f95bc42c6f5fbead81cd4e92d829",
+    "wof:geomhash":"7e9bbbddecd3354aa26f1a53b593825d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421184717,
-    "wof:lastmodified":1690927770,
+    "wof:lastmodified":1695886031,
     "wof:name":"San Raymundo",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/184/719/421184719.geojson
+++ b/data/421/184/719/421184719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111252,
-    "geom:area_square_m":1325968352.495103,
+    "geom:area_square_m":1325968107.872271,
     "geom:bbox":"-89.037527,15.223261,-88.492502,15.621417",
     "geom:latitude":15.44601,
     "geom:longitude":-88.77175,
@@ -139,12 +139,13 @@
         "qs_pg:id":1003288,
         "wd:id":"Q41804"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009420,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8e568b7e529003a7e4f3e7d827e0a3bf",
+    "wof:geomhash":"2119ab82c1b4411c3b40fe43bd9bcaa9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421184719,
-    "wof:lastmodified":1690927769,
+    "wof:lastmodified":1695886031,
     "wof:name":"Morales",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/421/184/975/421184975.geojson
+++ b/data/421/184/975/421184975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003647,
-    "geom:area_square_m":43569329.186424,
+    "geom:area_square_m":43569247.287465,
     "geom:bbox":"-91.539686,14.890289,-91.410219,14.963654",
     "geom:latitude":14.924856,
     "geom:longitude":-91.470028,
@@ -121,12 +121,13 @@
         "qs_pg:id":1015376,
         "wd:id":"Q2402432"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009428,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e239e49ebec2b16a6bcd78d7c8a42a5",
+    "wof:geomhash":"81d7e9f7095f9626aa89b8aa528e520a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421184975,
-    "wof:lastmodified":1690927770,
+    "wof:lastmodified":1695886031,
     "wof:name":"San Cristobal Totonicapan",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/185/525/421185525.geojson
+++ b/data/421/185/525/421185525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019168,
-    "geom:area_square_m":229372082.109076,
+    "geom:area_square_m":229372086.486975,
     "geom:bbox":"-89.69554,14.47193,-89.535176,14.687317",
     "geom:latitude":14.587026,
     "geom:longitude":-89.60729,
@@ -115,12 +115,13 @@
         "qs_pg:id":1025942,
         "wd:id":"Q541819"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009446,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"07997bbc47ee15a3c036e8d2f156c854",
+    "wof:geomhash":"856349c06ad934cba0f805448ff29426",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421185525,
-    "wof:lastmodified":1690927832,
+    "wof:lastmodified":1695886032,
     "wof:name":"Ipala",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/185/527/421185527.geojson
+++ b/data/421/185/527/421185527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018024,
-    "geom:area_square_m":215784235.434453,
+    "geom:area_square_m":215784302.799501,
     "geom:bbox":"-89.548797,14.406041,-89.348016,14.581684",
     "geom:latitude":14.488412,
     "geom:longitude":-89.447762,
@@ -118,12 +118,13 @@
         "qs_pg:id":1025943,
         "wd:id":"Q1954363"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009446,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cafd25018c7ad7238a3aa3f6f7595cde",
+    "wof:geomhash":"d98ed2a0f785cb00e48f74582fb32217",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421185527,
-    "wof:lastmodified":1690927831,
+    "wof:lastmodified":1695886032,
     "wof:name":"Concepcion La Minas",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/185/569/421185569.geojson
+++ b/data/421/185/569/421185569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07608,
-    "geom:area_square_m":904604859.723068,
+    "geom:area_square_m":904605433.563435,
     "geom:bbox":"-91.412674,15.752258,-91.043787,16.076909",
     "geom:latitude":15.932582,
     "geom:longitude":-91.2215,
@@ -203,12 +203,13 @@
         "qs_pg:id":1029767,
         "wd:id":"Q1645760"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009447,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab63c43bdcc1952cda48c0dd569e39bc",
+    "wof:geomhash":"c12c507be6e8ea537d2751cb91d4112d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":421185569,
-    "wof:lastmodified":1690927829,
+    "wof:lastmodified":1695886032,
     "wof:name":"Barillas",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/185/571/421185571.geojson
+++ b/data/421/185/571/421185571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007805,
-    "geom:area_square_m":92969215.212138,
+    "geom:area_square_m":92969297.972446,
     "geom:bbox":"-92.001412,15.444703,-91.85,15.639319",
     "geom:latitude":15.563145,
     "geom:longitude":-91.912013,
@@ -208,12 +208,13 @@
         "qs_pg:id":1029768,
         "wd:id":"Q1795844"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009447,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32dd9c34e5e876276e6e7559d1854c9e",
+    "wof:geomhash":"76c9b19968a9dd72d5b9c88cba5098d1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -223,7 +224,7 @@
         }
     ],
     "wof:id":421185571,
-    "wof:lastmodified":1690927832,
+    "wof:lastmodified":1695886115,
     "wof:name":"La Libertad",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/185/575/421185575.geojson
+++ b/data/421/185/575/421185575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004192,
-    "geom:area_square_m":49942475.698402,
+    "geom:area_square_m":49942678.119652,
     "geom:bbox":"-91.717904,15.465115,-91.645295,15.549605",
     "geom:latitude":15.508857,
     "geom:longitude":-91.683587,
@@ -115,12 +115,13 @@
         "qs_pg:id":1029769,
         "wd:id":"Q2402809"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009447,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0bf72aea079c57ca6a94dc0cf26d1cdb",
+    "wof:geomhash":"2ed97ae8f07d79f01ba090b1165bd922",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421185575,
-    "wof:lastmodified":1690927830,
+    "wof:lastmodified":1695886032,
     "wof:name":"Santiago Chimaltenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/185/999/421185999.geojson
+++ b/data/421/185/999/421185999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00943,
-    "geom:area_square_m":112905507.113774,
+    "geom:area_square_m":112905360.098049,
     "geom:bbox":"-90.486583,14.368405,-90.386454,14.546365",
     "geom:latitude":14.46936,
     "geom:longitude":-90.441676,
@@ -127,12 +127,13 @@
         "qs_pg:id":907425,
         "wd:id":"Q1440507"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009461,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c34241293a7c81796601b6b0c0974516",
+    "wof:geomhash":"2da47cab73218d33f996118e9dd079ff",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421185999,
-    "wof:lastmodified":1690927830,
+    "wof:lastmodified":1695886032,
     "wof:name":"Fraijanes",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/186/001/421186001.geojson
+++ b/data/421/186/001/421186001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039058,
-    "geom:area_square_m":466526515.29929,
+    "geom:area_square_m":466526682.077129,
     "geom:bbox":"-91.026451,14.906496,-90.649765,15.11269",
     "geom:latitude":14.986756,
     "geom:longitude":-90.821739,
@@ -121,12 +121,13 @@
         "qs_pg:id":907426,
         "wd:id":"Q2401953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009461,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d93512a419e8354215ae1a82704cabdd",
+    "wof:geomhash":"85dc2f6dc3addd5056f254695247d049",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421186001,
-    "wof:lastmodified":1690927718,
+    "wof:lastmodified":1695886028,
     "wof:name":"Joyabaj",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/186/319/421186319.geojson
+++ b/data/421/186/319/421186319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015827,
-    "geom:area_square_m":188760458.633375,
+    "geom:area_square_m":188760293.231073,
     "geom:bbox":"-91.539113,15.222538,-91.276499,15.382131",
     "geom:latitude":15.314562,
     "geom:longitude":-91.385827,
@@ -204,12 +204,13 @@
         "qs_pg:id":1063634,
         "wd:id":"Q984863"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009477,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"847f98f63f7f15726e0e4b38297ffb92",
+    "wof:geomhash":"62eab19f914866276d0c4aef30432e63",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":421186319,
-    "wof:lastmodified":1690927720,
+    "wof:lastmodified":1695886114,
     "wof:name":"Huehuetenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/187/937/421187937.geojson
+++ b/data/421/187/937/421187937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010935,
-    "geom:area_square_m":130874667.668712,
+    "geom:area_square_m":130874686.312115,
     "geom:bbox":"-91.045274,14.500157,-90.859094,14.602175",
     "geom:latitude":14.547825,
     "geom:longitude":-90.954652,
@@ -149,12 +149,13 @@
         "qs_pg:id":1086791,
         "wd:id":"Q1523949"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009528,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d9fd41c887a2d72cd889ef52e29ebe2",
+    "wof:geomhash":"101ed5a1ec45f07bf77cda2e92c83312",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421187937,
-    "wof:lastmodified":1690927698,
+    "wof:lastmodified":1695886026,
     "wof:name":"Acatenango",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/187/939/421187939.geojson
+++ b/data/421/187/939/421187939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204024,
-    "geom:area_square_m":2421318814.903828,
+    "geom:area_square_m":2421319250.384514,
     "geom:bbox":"-90.549014,15.991713,-90.027376,16.605996",
     "geom:latitude":16.305048,
     "geom:longitude":-90.247366,
@@ -130,12 +130,13 @@
         "qs_pg:id":1086793,
         "wd:id":"Q796634"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009528,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"21cc058bda7dd65bf02c9fd4f7eeac61",
+    "wof:geomhash":"e1c8bb051b8933c2ea5fdf53737d2a71",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421187939,
-    "wof:lastmodified":1690927697,
+    "wof:lastmodified":1695886026,
     "wof:name":"Sayaxche",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/188/729/421188729.geojson
+++ b/data/421/188/729/421188729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041301,
-    "geom:area_square_m":494159453.739767,
+    "geom:area_square_m":494159552.835861,
     "geom:bbox":"-89.425673,14.459925,-89.132271,14.803433",
     "geom:latitude":14.620965,
     "geom:longitude":-89.265813,
@@ -142,12 +142,13 @@
         "qs_pg:id":1103773,
         "wd:id":"Q3058634"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009576,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf3142fd719b0d07cec1fb9a3e9518ff",
+    "wof:geomhash":"c5722fba0671bb783795a16d2f3975e3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":421188729,
-    "wof:lastmodified":1690927709,
+    "wof:lastmodified":1695886028,
     "wof:name":"Esquipulas",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/188/895/421188895.geojson
+++ b/data/421/188/895/421188895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0383,
-    "geom:area_square_m":455845441.084781,
+    "geom:area_square_m":455845441.084826,
     "geom:bbox":"-89.7283712918,15.6126340658,-89.4122517757,15.8633922465",
     "geom:latitude":15.733188,
     "geom:longitude":-89.576082,
@@ -280,12 +280,13 @@
         "qs_pg:id":1104932,
         "wd:id":"Q5067516"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009587,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b0bd636f231228821dab634d6ab3bb9",
+    "wof:geomhash":"370589315306fe31db2950c9ec15976d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -295,7 +296,7 @@
         }
     ],
     "wof:id":421188895,
-    "wof:lastmodified":1582360594,
+    "wof:lastmodified":1695886028,
     "wof:name":"Chahal",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/188/897/421188897.geojson
+++ b/data/421/188/897/421188897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005355,
-    "geom:area_square_m":64081060.326574,
+    "geom:area_square_m":64080937.203066,
     "geom:bbox":"-90.908238,14.54536,-90.81386,14.660216",
     "geom:latitude":14.608293,
     "geom:longitude":-90.863315,
@@ -114,12 +114,13 @@
         "qs_pg:id":1104946,
         "wd:id":"Q1573465"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009587,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8af23f05104ca8237513c8c9867b593e",
+    "wof:geomhash":"b4b5e44b2ea8561a9f81c9c55a353bce",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421188897,
-    "wof:lastmodified":1690927709,
+    "wof:lastmodified":1695886028,
     "wof:name":"San Andres Iztapa",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/188/899/421188899.geojson
+++ b/data/421/188/899/421188899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001928,
-    "geom:area_square_m":23067051.809353,
+    "geom:area_square_m":23066904.578147,
     "geom:bbox":"-90.678325,14.567947,-90.61181,14.626841",
     "geom:latitude":14.5979,
     "geom:longitude":-90.647618,
@@ -124,12 +124,13 @@
         "qs_pg:id":1104965,
         "wd:id":"Q2607797"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009587,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e9d3f2925401056448bb276ef6a266d3",
+    "wof:geomhash":"d6389ba24fb1cf8595f611df0ad7b213",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421188899,
-    "wof:lastmodified":1690927709,
+    "wof:lastmodified":1695886028,
     "wof:name":"San Lucas Sacatepequez",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/189/121/421189121.geojson
+++ b/data/421/189/121/421189121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005358,
-    "geom:area_square_m":64148423.665764,
+    "geom:area_square_m":64148625.12169,
     "geom:bbox":"-90.748065,14.427785,-90.653529,14.524802",
     "geom:latitude":14.475958,
     "geom:longitude":-90.698746,
@@ -127,12 +127,13 @@
         "qs_pg:id":1110195,
         "wd:id":"Q119252"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009605,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5988053c9d3740ebe61b0f4fd294d202",
+    "wof:geomhash":"4954a96546584b484564ca2281d68d4b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421189121,
-    "wof:lastmodified":1690927706,
+    "wof:lastmodified":1695886028,
     "wof:name":"Santa Maria De Jesus",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/189/123/421189123.geojson
+++ b/data/421/189/123/421189123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000284,
-    "geom:area_square_m":3401541.235221,
+    "geom:area_square_m":3401540.636332,
     "geom:bbox":"-91.140067,14.710845,-91.12,14.7321",
     "geom:latitude":14.722679,
     "geom:longitude":-91.129233,
@@ -127,12 +127,13 @@
         "qs_pg:id":1110196,
         "wd:id":"Q2608981"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009605,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0bec229413790f03b2d144227d92dcf7",
+    "wof:geomhash":"d0fe5c18c5967d3ebda2dc033ead2973",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421189123,
-    "wof:lastmodified":1690927707,
+    "wof:lastmodified":1695886028,
     "wof:name":"Santa Catarina Palopo",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/189/125/421189125.geojson
+++ b/data/421/189/125/421189125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002327,
-    "geom:area_square_m":27832150.943456,
+    "geom:area_square_m":27832293.788938,
     "geom:bbox":"-91.139053,14.627076,-91.075024,14.700484",
     "geom:latitude":14.661867,
     "geom:longitude":-91.107458,
@@ -124,12 +124,13 @@
         "qs_pg:id":1110197,
         "wd:id":"Q2609248"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009605,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"93b72793f6bd3e6ebd4a63d43909fa1f",
+    "wof:geomhash":"db50794ee4f393d9f513d42b525c3487",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421189125,
-    "wof:lastmodified":1690927708,
+    "wof:lastmodified":1695886028,
     "wof:name":"San Antonio Palopo",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/189/489/421189489.geojson
+++ b/data/421/189/489/421189489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015305,
-    "geom:area_square_m":182239691.044435,
+    "geom:area_square_m":182239540.09342,
     "geom:bbox":"-91.533637,15.590651,-91.216014,15.692271",
     "geom:latitude":15.648978,
     "geom:longitude":-91.387123,
@@ -118,12 +118,13 @@
         "qs_pg:id":1113821,
         "wd:id":"Q2401833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009626,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"20bc4533dc7038861b7a634f3e53c3f0",
+    "wof:geomhash":"dbc2f0c49959b2422d3e0e489fae4414",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421189489,
-    "wof:lastmodified":1690927707,
+    "wof:lastmodified":1695886028,
     "wof:name":"San Juan Ixcoy",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/189/491/421189491.geojson
+++ b/data/421/189/491/421189491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052721,
-    "geom:area_square_m":631674088.522274,
+    "geom:area_square_m":631674102.43684,
     "geom:bbox":"-90.079051,14.162225,-89.771809,14.463902",
     "geom:latitude":14.311777,
     "geom:longitude":-89.930102,
@@ -213,12 +213,13 @@
         "qs_pg:id":1113825,
         "wd:id":"Q1023364"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009626,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f83fa11fc987202a74ea652f261f61b5",
+    "wof:geomhash":"73194fdf61237646406b56f796d7ba9b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":421189491,
-    "wof:lastmodified":1690927706,
+    "wof:lastmodified":1695886114,
     "wof:name":"Jutiapa",
     "wof:parent_id":85671723,
     "wof:placetype":"county",

--- a/data/421/190/247/421190247.geojson
+++ b/data/421/190/247/421190247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190147,
-    "geom:area_square_m":2263359136.329068,
+    "geom:area_square_m":2263359588.917297,
     "geom:bbox":"-90.817891,15.324619,-90.258398,16.041962",
     "geom:latitude":15.710176,
     "geom:longitude":-90.541307,
@@ -265,12 +265,13 @@
         "qs_pg:id":1119122,
         "wd:id":"Q867077"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009652,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"135c0da33590d9c10512ce9e712ebcef",
+    "wof:geomhash":"ef81e73850ffa066202d95524d4eb635",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -280,7 +281,7 @@
         }
     ],
     "wof:id":421190247,
-    "wof:lastmodified":1690927741,
+    "wof:lastmodified":1695886028,
     "wof:name":"Coban",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/190/249/421190249.geojson
+++ b/data/421/190/249/421190249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001062,
-    "geom:area_square_m":12694222.409125,
+    "geom:area_square_m":12694150.659746,
     "geom:bbox":"-91.250955,14.728774,-91.195271,14.765492",
     "geom:latitude":14.744065,
     "geom:longitude":-91.220687,
@@ -115,12 +115,13 @@
         "qs_pg:id":1119124,
         "wd:id":"Q2401852"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009652,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d6be297baea7cf0fda3745eddbd5f67c",
+    "wof:geomhash":"08eeaff51402e100add7d5538bc44e7e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421190249,
-    "wof:lastmodified":1690927741,
+    "wof:lastmodified":1695886028,
     "wof:name":"Santa Cruz La Laguna",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/190/493/421190493.geojson
+++ b/data/421/190/493/421190493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023706,
-    "geom:area_square_m":282365838.8705,
+    "geom:area_square_m":282365938.983766,
     "geom:bbox":"-91.72755,15.48053,-91.485017,15.647843",
     "geom:latitude":15.573163,
     "geom:longitude":-91.584326,
@@ -118,12 +118,13 @@
         "qs_pg:id":1119668,
         "wd:id":"Q2608975"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009659,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02e6bc429f96b15ad08e319dfdae79f2",
+    "wof:geomhash":"dad6aea93af8d270d4faa9c540aee90e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421190493,
-    "wof:lastmodified":1690927742,
+    "wof:lastmodified":1695886028,
     "wof:name":"Todos Santos Cuchumatan",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/190/497/421190497.geojson
+++ b/data/421/190/497/421190497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007591,
-    "geom:area_square_m":90891427.097676,
+    "geom:area_square_m":90891432.569617,
     "geom:bbox":"-90.881611,14.391057,-90.749494,14.510649",
     "geom:latitude":14.461068,
     "geom:longitude":-90.818252,
@@ -126,12 +126,13 @@
         "qs_pg:id":1119671,
         "wd:id":"Q2608214"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009659,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bcd8ffdee1a9667ea969b181dc7cba80",
+    "wof:geomhash":"51911c7777d76344193018c2eaf5a557",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421190497,
-    "wof:lastmodified":1690927738,
+    "wof:lastmodified":1695886028,
     "wof:name":"Alotenango",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/190/499/421190499.geojson
+++ b/data/421/190/499/421190499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010072,
-    "geom:area_square_m":120300652.942951,
+    "geom:area_square_m":120300885.275523,
     "geom:bbox":"-91.900267,14.90341,-91.768312,15.081948",
     "geom:latitude":15.000674,
     "geom:longitude":-91.834513,
@@ -181,12 +181,13 @@
         "qs_pg:id":1119672,
         "wd:id":"Q1023981"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009659,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b026a0623609f7321dd0f39b66267584",
+    "wof:geomhash":"ba7c2cdbf216759ae45c5ac05c9c7740",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":421190499,
-    "wof:lastmodified":1690927739,
+    "wof:lastmodified":1695886115,
     "wof:name":"San Marcos",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/421/190/501/421190501.geojson
+++ b/data/421/190/501/421190501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053908,
-    "geom:area_square_m":646685015.48685,
+    "geom:area_square_m":646685354.545935,
     "geom:bbox":"-90.673865,13.879253,-90.418084,14.200696",
     "geom:latitude":14.035003,
     "geom:longitude":-90.546097,
@@ -124,12 +124,13 @@
         "qs_pg:id":1119673,
         "wd:id":"Q2402116"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009659,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61b5bd391e10137f0f5f47e982f894c7",
+    "wof:geomhash":"da337712735a2851666db13ab6616743",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421190501,
-    "wof:lastmodified":1690927740,
+    "wof:lastmodified":1695886028,
     "wof:name":"Taxisco",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/421/190/503/421190503.geojson
+++ b/data/421/190/503/421190503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012473,
-    "geom:area_square_m":149093057.228621,
+    "geom:area_square_m":149093135.580978,
     "geom:bbox":"-91.263785,14.737215,-91.099139,14.896922",
     "geom:latitude":14.823345,
     "geom:longitude":-91.180381,
@@ -148,12 +148,13 @@
         "qs_pg:id":1119674,
         "wd:id":"Q602423"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009659,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"044029f0db452e6081b398e254496a91",
+    "wof:geomhash":"7c47eef86713f79e76d7acd558440b57",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":421190503,
-    "wof:lastmodified":1690927738,
+    "wof:lastmodified":1695886028,
     "wof:name":"Solola",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/190/509/421190509.geojson
+++ b/data/421/190/509/421190509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006211,
-    "geom:area_square_m":74321019.914932,
+    "geom:area_square_m":74320963.667412,
     "geom:bbox":"-91.190495,14.518313,-91.10867,14.662499",
     "geom:latitude":14.594755,
     "geom:longitude":-91.145722,
@@ -115,12 +115,13 @@
         "qs_pg:id":1119676,
         "wd:id":"Q2608186"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009660,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ff5bdda56ddbf157262c42d0bec5c1f4",
+    "wof:geomhash":"59267e349926e82d606596a62db70a44",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421190509,
-    "wof:lastmodified":1690927740,
+    "wof:lastmodified":1695886028,
     "wof:name":"San Lucas Toliman",
     "wof:parent_id":85671695,
     "wof:placetype":"county",

--- a/data/421/191/199/421191199.geojson
+++ b/data/421/191/199/421191199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034656,
-    "geom:area_square_m":414236215.622191,
+    "geom:area_square_m":414236574.016308,
     "geom:bbox":"-90.904055,14.724145,-90.619227,14.935404",
     "geom:latitude":14.840711,
     "geom:longitude":-90.781595,
@@ -121,12 +121,13 @@
         "qs_pg:id":61118,
         "wd:id":"Q2607954"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009684,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ead7e132b3e28d2dfa1d867a5cd09130",
+    "wof:geomhash":"165735ac2aac83f487ce200da9687834",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421191199,
-    "wof:lastmodified":1690927736,
+    "wof:lastmodified":1695886029,
     "wof:name":"San Martin Jilotepeque",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/191/201/421191201.geojson
+++ b/data/421/191/201/421191201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017798,
-    "geom:area_square_m":213310100.220751,
+    "geom:area_square_m":213310413.442199,
     "geom:bbox":"-90.403149,14.162749,-90.193628,14.333603",
     "geom:latitude":14.249581,
     "geom:longitude":-90.28395,
@@ -187,12 +187,13 @@
         "qs_pg:id":61138,
         "wd:id":"Q1015941"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009684,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e2182b59d4cb21e4fd91607bfd228aa1",
+    "wof:geomhash":"23f7bb5074a12db3d751e82f24292992",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":421191201,
-    "wof:lastmodified":1690927737,
+    "wof:lastmodified":1695886114,
     "wof:name":"Cuilapa",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/421/191/319/421191319.geojson
+++ b/data/421/191/319/421191319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000629,
-    "geom:area_square_m":7529244.647499,
+    "geom:area_square_m":7529324.558647,
     "geom:bbox":"-91.527528,14.493014,-91.500698,14.52298",
     "geom:latitude":14.507866,
     "geom:longitude":-91.514324,
@@ -162,12 +162,13 @@
         "wd:id":"Q1748775",
         "wk:page":"San Gabriel, Suchitep\u00e9quez"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009688,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a03fe8b8ede988f67ad0db9bcae64dcb",
+    "wof:geomhash":"50f18fafe6d3f69278a15a36a1fea5b1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":421191319,
-    "wof:lastmodified":1690927737,
+    "wof:lastmodified":1695886115,
     "wof:name":"San Gabriel",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/421/191/321/421191321.geojson
+++ b/data/421/191/321/421191321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020088,
-    "geom:area_square_m":239908344.956927,
+    "geom:area_square_m":239908542.409312,
     "geom:bbox":"-91.425368,14.93388,-91.232718,15.138051",
     "geom:latitude":15.012619,
     "geom:longitude":-91.316572,
@@ -120,12 +120,13 @@
         "wd:id":"Q2402472",
         "wk:page":"Santa Mar\u00eda Chiquimula"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009688,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8846c4008f11b70adf729cb24635ea9f",
+    "wof:geomhash":"5b295e1095d69757e6825adb2332943d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421191321,
-    "wof:lastmodified":1690927738,
+    "wof:lastmodified":1695886029,
     "wof:name":"Santa Maria Chiquimula",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/191/461/421191461.geojson
+++ b/data/421/191/461/421191461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017611,
-    "geom:area_square_m":210697508.522871,
+    "geom:area_square_m":210697508.522913,
     "geom:bbox":"-90.5797505519,14.537459206,-90.3794126278,14.7163742567",
     "geom:latitude":14.635034,
     "geom:longitude":-90.480256,
@@ -651,12 +651,13 @@
         "hasc:id":"GT.GU.CG",
         "qs_pg:id":1137320
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009693,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0aeb93f4fa40ea3030f55c77a2ea0c14",
+    "wof:geomhash":"4c3de33e0f1ff2236301576dae52cf2b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -666,7 +667,7 @@
         }
     ],
     "wof:id":421191461,
-    "wof:lastmodified":1582360595,
+    "wof:lastmodified":1695886029,
     "wof:name":"Guatemala",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/191/463/421191463.geojson
+++ b/data/421/191/463/421191463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034523,
-    "geom:area_square_m":411866868.800058,
+    "geom:area_square_m":411866769.324697,
     "geom:bbox":"-91.632481,15.134357,-91.365624,15.329908",
     "geom:latitude":15.245263,
     "geom:longitude":-91.48323,
@@ -118,12 +118,13 @@
         "qs_pg:id":1137322,
         "wd:id":"Q539311"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009693,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b83ade87a6d4f9bd4a8c34dae0dce011",
+    "wof:geomhash":"2b2df28e4972af0d8940d2a67d87ef4f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421191463,
-    "wof:lastmodified":1690927735,
+    "wof:lastmodified":1695886029,
     "wof:name":"Malacatancito",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/191/465/421191465.geojson
+++ b/data/421/191/465/421191465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0195,
-    "geom:area_square_m":233381840.528113,
+    "geom:area_square_m":233381755.455297,
     "geom:bbox":"-90.291248,14.466735,-90.115131,14.671291",
     "geom:latitude":14.554226,
     "geom:longitude":-90.20394,
@@ -118,12 +118,13 @@
         "qs_pg:id":1137324,
         "wd:id":"Q1749104"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009693,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7bc590beb6c069087acbd1bcd155820d",
+    "wof:geomhash":"2a33700caaf9c5fba107f222edccd505",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421191465,
-    "wof:lastmodified":1690927735,
+    "wof:lastmodified":1695886029,
     "wof:name":"Mataquescuintla",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/421/191/467/421191467.geojson
+++ b/data/421/191/467/421191467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004294,
-    "geom:area_square_m":51372371.321923,
+    "geom:area_square_m":51372538.998473,
     "geom:bbox":"-90.783313,14.603871,-90.706138,14.721835",
     "geom:latitude":14.657429,
     "geom:longitude":-90.745369,
@@ -130,12 +130,13 @@
         "qs_pg:id":1137327,
         "wd:id":"Q2574245"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009693,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8bd029681aa66bf926919911697075b6",
+    "wof:geomhash":"96cd7330c0745f57905f84a94cabc6ae",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421191467,
-    "wof:lastmodified":1690927736,
+    "wof:lastmodified":1695886029,
     "wof:name":"Sumpango",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/194/695/421194695.geojson
+++ b/data/421/194/695/421194695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133986,
-    "geom:area_square_m":1596861093.242099,
+    "geom:area_square_m":1596861489.86601,
     "geom:bbox":"-89.623931,15.158169,-89.104666,15.710134",
     "geom:latitude":15.452768,
     "geom:longitude":-89.401407,
@@ -124,12 +124,13 @@
         "qs_pg:id":897114,
         "wd:id":"Q1020153"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009816,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"92dfd12dbb2c2e5d65edd998844f4eb4",
+    "wof:geomhash":"f882e2345987a9e0c54e6e73c3855ca9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421194695,
-    "wof:lastmodified":1690927655,
+    "wof:lastmodified":1695886025,
     "wof:name":"El Estor",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/421/195/013/421195013.geojson
+++ b/data/421/195/013/421195013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004101,
-    "geom:area_square_m":49024523.979856,
+    "geom:area_square_m":49024523.979836,
     "geom:bbox":"-91.4713054325,14.7668396176,-91.4038348615,14.8631636519",
     "geom:latitude":14.815605,
     "geom:longitude":-91.439086,
@@ -283,12 +283,13 @@
         "qs_pg:id":115419,
         "wd:id":"Q5033573"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009828,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c60fcc202e329072f8105c8b00cd92f1",
+    "wof:geomhash":"8266eb1a47b38e2ba91a6efccd5aa8be",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -298,7 +299,7 @@
         }
     ],
     "wof:id":421195013,
-    "wof:lastmodified":1582360592,
+    "wof:lastmodified":1695886025,
     "wof:name":"Cantel",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/195/541/421195541.geojson
+++ b/data/421/195/541/421195541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003828,
-    "geom:area_square_m":45682299.015259,
+    "geom:area_square_m":45682679.511917,
     "geom:bbox":"-91.332117,15.099563,-91.207352,15.206353",
     "geom:latitude":15.151511,
     "geom:longitude":-91.278477,
@@ -124,12 +124,13 @@
         "qs_pg:id":115431,
         "wd:id":"Q3472669"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009851,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf07e113f8484fcc9f7faab79906e82d",
+    "wof:geomhash":"a9b8fbfcb8ad5530387d003ad5cf1532",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421195541,
-    "wof:lastmodified":1690927653,
+    "wof:lastmodified":1695886025,
     "wof:name":"Santa Lucia La Reforma",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/195/543/421195543.geojson
+++ b/data/421/195/543/421195543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011206,
-    "geom:area_square_m":134233072.45587,
+    "geom:area_square_m":134232951.807786,
     "geom:bbox":"-90.340681,14.300051,-90.213947,14.478544",
     "geom:latitude":14.371642,
     "geom:longitude":-90.272281,
@@ -118,12 +118,13 @@
         "qs_pg:id":115437,
         "wd:id":"Q2402348"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009851,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68aa3605d5c47c1d6e674bb2b952d864",
+    "wof:geomhash":"0b9155250090020e8fde9c691188babf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421195543,
-    "wof:lastmodified":1690927652,
+    "wof:lastmodified":1695886025,
     "wof:name":"Nueva Santa Rosa",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/421/195/547/421195547.geojson
+++ b/data/421/195/547/421195547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004146,
-    "geom:area_square_m":49527047.423033,
+    "geom:area_square_m":49526880.257263,
     "geom:bbox":"-91.753379,14.921762,-91.668505,15.009802",
     "geom:latitude":14.962154,
     "geom:longitude":-91.709057,
@@ -115,12 +115,13 @@
         "qs_pg:id":115440,
         "wd:id":"Q2219943"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009851,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec3de8802f62f215e4895294f7aaace7",
+    "wof:geomhash":"524275680cf13ceb51efd6e29787efd1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421195547,
-    "wof:lastmodified":1690927653,
+    "wof:lastmodified":1695886025,
     "wof:name":"San Antonio Sacatepequez",
     "wof:parent_id":85671661,
     "wof:placetype":"county",

--- a/data/421/196/435/421196435.geojson
+++ b/data/421/196/435/421196435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087794,
-    "geom:area_square_m":1047270071.686424,
+    "geom:area_square_m":1047270176.5906,
     "geom:bbox":"-89.223291,15.068382,-88.86915,15.507304",
     "geom:latitude":15.268958,
     "geom:longitude":-89.060601,
@@ -121,12 +121,13 @@
         "qs_pg:id":354384,
         "wd:id":"Q1020130"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009881,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f8f9ba90c26a601d9a63eb7da204be29",
+    "wof:geomhash":"1a99b7661acfa5919a105dfdbccaf008",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421196435,
-    "wof:lastmodified":1690927734,
+    "wof:lastmodified":1695886028,
     "wof:name":"Los Amates",
     "wof:parent_id":85671709,
     "wof:placetype":"county",

--- a/data/421/196/545/421196545.geojson
+++ b/data/421/196/545/421196545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06899,
-    "geom:area_square_m":822026676.879183,
+    "geom:area_square_m":822025726.297298,
     "geom:bbox":"-90.984806,15.21834,-90.62905,15.74319",
     "geom:latitude":15.504836,
     "geom:longitude":-90.819286,
@@ -127,12 +127,13 @@
         "qs_pg:id":772714,
         "wd:id":"Q2621539"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009885,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"10b045160a1b57c1f8ab8e60dc3c29d4",
+    "wof:geomhash":"aea4ce041bc975cd7b6d3e0aa5070d57",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421196545,
-    "wof:lastmodified":1690927733,
+    "wof:lastmodified":1695886028,
     "wof:name":"Uspantan",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/196/547/421196547.geojson
+++ b/data/421/196/547/421196547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017888,
-    "geom:area_square_m":214129095.960157,
+    "geom:area_square_m":214129110.600927,
     "geom:bbox":"-91.4234,14.327209,-91.26453,14.646102",
     "geom:latitude":14.519059,
     "geom:longitude":-91.349622,
@@ -121,12 +121,13 @@
         "qs_pg:id":772715,
         "wd:id":"Q2402199"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009885,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bcfb67c6675032c534229203138b2c01",
+    "wof:geomhash":"b45fd11275f5d9711aaf7134a4794fa1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421196547,
-    "wof:lastmodified":1690927734,
+    "wof:lastmodified":1695886029,
     "wof:name":"Chicacao",
     "wof:parent_id":85671683,
     "wof:placetype":"county",

--- a/data/421/196/995/421196995.geojson
+++ b/data/421/196/995/421196995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004802,
-    "geom:area_square_m":57358740.044272,
+    "geom:area_square_m":57358822.12237,
     "geom:bbox":"-91.242071,14.934697,-91.141826,15.004506",
     "geom:latitude":14.971729,
     "geom:longitude":-91.194158,
@@ -118,12 +118,13 @@
         "qs_pg:id":1264010,
         "wd:id":"Q2402369"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3093b169286a8994c71b374bb8b8fc85",
+    "wof:geomhash":"a1818bfbdb58d2364fbed3b04e91f64b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421196995,
-    "wof:lastmodified":1690927733,
+    "wof:lastmodified":1695886028,
     "wof:name":"Patzite",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/197/631/421197631.geojson
+++ b/data/421/197/631/421197631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00565,
-    "geom:area_square_m":67339154.645678,
+    "geom:area_square_m":67338970.87872,
     "geom:bbox":"-91.754106,15.396655,-91.64744,15.492758",
     "geom:latitude":15.445231,
     "geom:longitude":-91.709801,
@@ -117,12 +117,13 @@
         "wd:id":"Q2402611",
         "wk:page":"Colotenango"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009920,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eaa4b4041d0cb03b6f4d11cdfaaec514",
+    "wof:geomhash":"ac74716931042d76132478fb79ddecbd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421197631,
-    "wof:lastmodified":1690927749,
+    "wof:lastmodified":1695886029,
     "wof:name":"Colotenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/198/237/421198237.geojson
+++ b/data/421/198/237/421198237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044297,
-    "geom:area_square_m":529809020.998717,
+    "geom:area_square_m":529809513.448153,
     "geom:bbox":"-89.948392,14.551888,-89.75,14.875513",
     "geom:latitude":14.702389,
     "geom:longitude":-89.85409,
@@ -118,12 +118,13 @@
         "qs_pg:id":401858,
         "wd:id":"Q739778"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459009941,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c3df9ce9e0b9e2fac73bc9c9ee32527e",
+    "wof:geomhash":"cf1fa46f16bb2885781875be9134a5c3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421198237,
-    "wof:lastmodified":1690927730,
+    "wof:lastmodified":1695886028,
     "wof:name":"San Pedro Pinula",
     "wof:parent_id":85671719,
     "wof:placetype":"county",

--- a/data/421/200/683/421200683.geojson
+++ b/data/421/200/683/421200683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001431,
-    "geom:area_square_m":17104250.24284,
+    "geom:area_square_m":17104258.888991,
     "geom:bbox":"-91.489298,14.853271,-91.439205,14.895958",
     "geom:latitude":14.877269,
     "geom:longitude":-91.46249,
@@ -126,12 +126,13 @@
         "qs_pg:id":209389,
         "wd:id":"Q2717997"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010034,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a3f1e2e3a498fb6a1deb4ce3324e9b4",
+    "wof:geomhash":"11a3aabc45c78640a4b9bf2596759bec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421200683,
-    "wof:lastmodified":1690927755,
+    "wof:lastmodified":1695886029,
     "wof:name":"Salcaja",
     "wof:parent_id":85671651,
     "wof:placetype":"county",

--- a/data/421/200/685/421200685.geojson
+++ b/data/421/200/685/421200685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014279,
-    "geom:area_square_m":170207554.761614,
+    "geom:area_square_m":170207992.657658,
     "geom:bbox":"-91.169411,15.368535,-90.868373,15.482927",
     "geom:latitude":15.425525,
     "geom:longitude":-91.019913,
@@ -121,12 +121,13 @@
         "qs_pg:id":209390,
         "wd:id":"Q2121567"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010035,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d69fb88e62221e39e28b9b40625fa77a",
+    "wof:geomhash":"75a863ac25706b792715fe7d9a224f3c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421200685,
-    "wof:lastmodified":1690927754,
+    "wof:lastmodified":1695886029,
     "wof:name":"San Juan Cotzal",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/200/731/421200731.geojson
+++ b/data/421/200/731/421200731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046039,
-    "geom:area_square_m":544609617.45438,
+    "geom:area_square_m":544609792.180904,
     "geom:bbox":"-90.188496,16.828406,-89.892908,17.107824",
     "geom:latitude":16.930285,
     "geom:longitude":-90.072747,
@@ -134,12 +134,13 @@
         "wd:id":"Q1113394",
         "wk:page":"San Benito, El Pet\u00e9n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010036,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9fb269644bc91b0af3fa7de43168f462",
+    "wof:geomhash":"59df14ae0d8ae017b301a7bca07e2a2f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421200731,
-    "wof:lastmodified":1690927753,
+    "wof:lastmodified":1695886029,
     "wof:name":"San Benito",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/201/163/421201163.geojson
+++ b/data/421/201/163/421201163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011053,
-    "geom:area_square_m":131747527.023573,
+    "geom:area_square_m":131747534.424951,
     "geom:bbox":"-91.627535,15.351318,-91.503633,15.50609",
     "geom:latitude":15.4293,
     "geom:longitude":-91.558363,
@@ -147,12 +147,13 @@
         "wd:id":"Q2402108",
         "wk:page":"San Sebasti\u00e1n Huehuetenango"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010058,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b8634fbfed4da4ddc00f2f857792f0a6",
+    "wof:geomhash":"1b3b9e9240d36e488e0df02a74750bb1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421201163,
-    "wof:lastmodified":1690927761,
+    "wof:lastmodified":1695886029,
     "wof:name":"San Sebastian Huehuetenango",
     "wof:parent_id":85671641,
     "wof:placetype":"county",

--- a/data/421/201/585/421201585.geojson
+++ b/data/421/201/585/421201585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009195,
-    "geom:area_square_m":110128117.209837,
+    "geom:area_square_m":110128052.427071,
     "geom:bbox":"-90.765261,14.32904,-90.642731,14.470981",
     "geom:latitude":14.395721,
     "geom:longitude":-90.703007,
@@ -151,12 +151,13 @@
         "qs_pg:id":1263960,
         "wd:id":"Q523244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010077,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d0b3c55b02414e580d8869f003414a6",
+    "wof:geomhash":"2d615dbe0212db80d133f92d5afca404",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":421201585,
-    "wof:lastmodified":1690927762,
+    "wof:lastmodified":1695886031,
     "wof:name":"Palin",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/201/591/421201591.geojson
+++ b/data/421/201/591/421201591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005583,
-    "geom:area_square_m":66770602.370934,
+    "geom:area_square_m":66770571.444897,
     "geom:bbox":"-90.541198,14.671394,-90.452491,14.809597",
     "geom:latitude":14.728268,
     "geom:longitude":-90.495941,
@@ -139,12 +139,13 @@
         "qs_pg:id":1263967,
         "wd:id":"Q1027001"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010077,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e4cd619d4fb613d2517e1eb6b738927",
+    "wof:geomhash":"897f60fa6cab8814abbae68187d4449e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421201591,
-    "wof:lastmodified":1690927761,
+    "wof:lastmodified":1695886029,
     "wof:name":"Chinautla",
     "wof:parent_id":85671681,
     "wof:placetype":"county",

--- a/data/421/201/597/421201597.geojson
+++ b/data/421/201/597/421201597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009365,
-    "geom:area_square_m":111836936.527194,
+    "geom:area_square_m":111836728.768066,
     "geom:bbox":"-91.172802,14.936311,-91.067331,15.111444",
     "geom:latitude":15.040649,
     "geom:longitude":-91.122072,
@@ -180,12 +180,13 @@
         "qs_pg:id":1264008,
         "wd:id":"Q693140"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010077,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d49ef68e438052307cb7072f6c398253",
+    "wof:geomhash":"0ce5923a0e14631dc22abc955f9be4aa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421201597,
-    "wof:lastmodified":1690927761,
+    "wof:lastmodified":1695886115,
     "wof:name":"Santa Cruz Del Quiche",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/201/599/421201599.geojson
+++ b/data/421/201/599/421201599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005568,
-    "geom:area_square_m":66640044.798857,
+    "geom:area_square_m":66639788.026613,
     "geom:bbox":"-90.77678,14.475824,-90.687328,14.61211",
     "geom:latitude":14.546206,
     "geom:longitude":-90.724219,
@@ -288,12 +288,13 @@
         "qs_pg:id":1264013,
         "wd:id":"Q212773"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010077,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63cf06cff807d7ceb15069beeac902c7",
+    "wof:geomhash":"858046b92afc1c0cfd7e7e5ec71e5a78",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -303,7 +304,7 @@
         }
     ],
     "wof:id":421201599,
-    "wof:lastmodified":1690927760,
+    "wof:lastmodified":1695886029,
     "wof:name":"Antigua Guatemala",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/202/273/421202273.geojson
+++ b/data/421/202/273/421202273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13068,
-    "geom:area_square_m":1546759478.333086,
+    "geom:area_square_m":1546759554.660823,
     "geom:bbox":"-89.864536,16.630214,-89.326879,17.01306",
     "geom:latitude":16.819108,
     "geom:longitude":-89.578346,
@@ -156,12 +156,13 @@
         "wd:id":"Q1005733",
         "wk:page":"Santa Ana, El Pet\u00e9n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010111,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b8152da1cb49d85a60d70644a3627c4c",
+    "wof:geomhash":"5ce7f2a78fbc4038ea3ecdb635eb5e22",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":421202273,
-    "wof:lastmodified":1690927683,
+    "wof:lastmodified":1695886114,
     "wof:name":"Santa Ana",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/202/281/421202281.geojson
+++ b/data/421/202/281/421202281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018253,
-    "geom:area_square_m":219041299.669687,
+    "geom:area_square_m":219041424.525943,
     "geom:bbox":"-90.990581,13.913139,-90.747084,14.034233",
     "geom:latitude":13.958653,
     "geom:longitude":-90.883222,
@@ -295,12 +295,13 @@
         "qs_pg:id":220309,
         "wd:id":"Q173718"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010111,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee34a829908fed66a20307298245d2b2",
+    "wof:geomhash":"924804b4f0d883cfac1e825742643622",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -310,7 +311,7 @@
         }
     ],
     "wof:id":421202281,
-    "wof:lastmodified":1690927683,
+    "wof:lastmodified":1695886114,
     "wof:name":"San Jose",
     "wof:parent_id":85671677,
     "wof:placetype":"county",

--- a/data/421/203/203/421203203.geojson
+++ b/data/421/203/203/421203203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027995,
-    "geom:area_square_m":335366144.738273,
+    "geom:area_square_m":335366219.367263,
     "geom:bbox":"-92.037666,14.229147,-91.779721,14.435118",
     "geom:latitude":14.34929,
     "geom:longitude":-91.884976,
@@ -150,12 +150,13 @@
         "wd:id":"Q958349",
         "wk:page":"Champerico"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010143,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d12ff107907f74cc7ef5952dad1d6223",
+    "wof:geomhash":"eca0010ab39b54fa6bbd8164a0ac3e93",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":421203203,
-    "wof:lastmodified":1690927678,
+    "wof:lastmodified":1695886026,
     "wof:name":"Champerico",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/421/203/223/421203223.geojson
+++ b/data/421/203/223/421203223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010865,
-    "geom:area_square_m":130045986.872586,
+    "geom:area_square_m":130045907.860978,
     "geom:bbox":"-91.128217,14.452489,-90.999745,14.611134",
     "geom:latitude":14.533476,
     "geom:longitude":-91.074423,
@@ -121,12 +121,13 @@
         "qs_pg:id":230282,
         "wd:id":"Q1254201"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d51fac2ddea7cfacffa2f2b123819a7e",
+    "wof:geomhash":"e14047812196b2cbe3425d189ef1f1c2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421203223,
-    "wof:lastmodified":1690927680,
+    "wof:lastmodified":1695886026,
     "wof:name":"Pochuta",
     "wof:parent_id":85671671,
     "wof:placetype":"county",

--- a/data/421/203/225/421203225.geojson
+++ b/data/421/203/225/421203225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091896,
-    "geom:area_square_m":1090451486.377804,
+    "geom:area_square_m":1090451359.518867,
     "geom:bbox":"-89.953657,16.236301,-89.191734,16.441509",
     "geom:latitude":16.333442,
     "geom:longitude":-89.546634,
@@ -129,12 +129,13 @@
         "qs_pg:id":230284,
         "wd:id":"Q385588"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ded0991b9c3006ae4976a0158ed63a9c",
+    "wof:geomhash":"51f680944e4e2eefa98c19c5bfb615d8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421203225,
-    "wof:lastmodified":1690927681,
+    "wof:lastmodified":1695886026,
     "wof:name":"Poptun",
     "wof:parent_id":85671647,
     "wof:placetype":"county",

--- a/data/421/203/475/421203475.geojson
+++ b/data/421/203/475/421203475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043104,
-    "geom:area_square_m":514304740.273664,
+    "geom:area_square_m":514304861.848129,
     "geom:bbox":"-90.32975,15.128684,-89.855595,15.305067",
     "geom:latitude":15.215476,
     "geom:longitude":-90.038653,
@@ -124,12 +124,13 @@
         "qs_pg:id":231702,
         "wd:id":"Q536249"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010153,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"97684bfd283a81783961216c20eea9df",
+    "wof:geomhash":"491c76898773e4c83728f66e9ec208c4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421203475,
-    "wof:lastmodified":1690927680,
+    "wof:lastmodified":1695886026,
     "wof:name":"Purula",
     "wof:parent_id":85671635,
     "wof:placetype":"county",

--- a/data/421/203/515/421203515.geojson
+++ b/data/421/203/515/421203515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003777,
-    "geom:area_square_m":45209629.559258,
+    "geom:area_square_m":45209546.262437,
     "geom:bbox":"-90.87464,14.493193,-90.783591,14.56575",
     "geom:latitude":14.528139,
     "geom:longitude":-90.83076,
@@ -121,12 +121,13 @@
         "qs_pg:id":232581,
         "wd:id":"Q2400763"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010155,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9ac4f2a41c0504b15926c57c553d3d50",
+    "wof:geomhash":"fa051233ef3e714528ff0a16205a9988",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421203515,
-    "wof:lastmodified":1690927682,
+    "wof:lastmodified":1695886026,
     "wof:name":"San Miguel Duenas",
     "wof:parent_id":85671687,
     "wof:placetype":"county",

--- a/data/421/203/587/421203587.geojson
+++ b/data/421/203/587/421203587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049842,
-    "geom:area_square_m":598064983.101914,
+    "geom:area_square_m":598064970.780412,
     "geom:bbox":"-90.450763,13.791675,-90.203115,14.190845",
     "geom:latitude":13.973624,
     "geom:longitude":-90.334701,
@@ -123,12 +123,13 @@
         "qs_pg:id":233704,
         "wd:id":"Q202128"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010157,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"498655cf66aa90abad85865ad5d19aaf",
+    "wof:geomhash":"543b9b13ba510a2f5ffcfba446e8cc2f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421203587,
-    "wof:lastmodified":1690927679,
+    "wof:lastmodified":1695886026,
     "wof:name":"Chiquimulilla",
     "wof:parent_id":85671705,
     "wof:placetype":"county",

--- a/data/421/204/021/421204021.geojson
+++ b/data/421/204/021/421204021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029273,
-    "geom:area_square_m":349954843.723604,
+    "geom:area_square_m":349955085.292037,
     "geom:bbox":"-89.716908,14.702861,-89.441896,14.878498",
     "geom:latitude":14.80128,
     "geom:longitude":-89.578083,
@@ -216,12 +216,13 @@
         "qs_pg:id":237183,
         "wd:id":"Q261613"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010171,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27b25b55db3a2d21be47042a9b636606",
+    "wof:geomhash":"926eeb08c34aaa526e85dc452aca7201",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":421204021,
-    "wof:lastmodified":1690927678,
+    "wof:lastmodified":1695886114,
     "wof:name":"Chiquimula",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/421/204/285/421204285.geojson
+++ b/data/421/204/285/421204285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019103,
-    "geom:area_square_m":227769030.780583,
+    "geom:area_square_m":227769007.315344,
     "geom:bbox":"-91.18365,15.318978,-90.87943,15.42049",
     "geom:latitude":15.365566,
     "geom:longitude":-91.01466,
@@ -118,12 +118,13 @@
         "qs_pg:id":238979,
         "wd:id":"Q2402499"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010179,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb2c72704786e227d4ccb5f60d83cce9",
+    "wof:geomhash":"6b040b205fd252d3f2fe912166987fb4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421204285,
-    "wof:lastmodified":1690927676,
+    "wof:lastmodified":1695886027,
     "wof:name":"Cunen",
     "wof:parent_id":85671733,
     "wof:placetype":"county",

--- a/data/421/204/387/421204387.geojson
+++ b/data/421/204/387/421204387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06706,
-    "geom:area_square_m":803012256.054174,
+    "geom:area_square_m":803011737.891644,
     "geom:bbox":"-92.171987,14.187542,-91.652474,14.591547",
     "geom:latitude":14.439028,
     "geom:longitude":-91.871898,
@@ -189,12 +189,13 @@
         "qs_pg:id":239636,
         "wd:id":"Q1023393"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010184,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d25441781f47fb2a569188f276aba80",
+    "wof:geomhash":"9d438602895f9ecaf2eb39a9004c1d9b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421204387,
-    "wof:lastmodified":1690927678,
+    "wof:lastmodified":1695886114,
     "wof:name":"Retalhuleu",
     "wof:parent_id":85671659,
     "wof:placetype":"county",

--- a/data/421/204/557/421204557.geojson
+++ b/data/421/204/557/421204557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14008,
-    "geom:area_square_m":1665910410.088709,
+    "geom:area_square_m":1665910608.54733,
     "geom:bbox":"-90.51031,15.704943,-89.929452,16.073305",
     "geom:latitude":15.891763,
     "geom:longitude":-90.222194,
@@ -139,12 +139,13 @@
         "qs_pg:id":241713,
         "wd:id":"Q275980"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010190,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9331386ccefc7f08379ac7cbb8b49d0d",
+    "wof:geomhash":"424b2cfa51ef81f1eee18a45f2664e0b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421204557,
-    "wof:lastmodified":1690927674,
+    "wof:lastmodified":1695886027,
     "wof:name":"Chisec",
     "wof:parent_id":85671665,
     "wof:placetype":"county",

--- a/data/421/204/771/421204771.geojson
+++ b/data/421/204/771/421204771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020214,
-    "geom:area_square_m":241546234.964656,
+    "geom:area_square_m":241545819.642344,
     "geom:bbox":"-91.446226,14.823754,-91.179002,14.961519",
     "geom:latitude":14.897033,
     "geom:longitude":-91.321388,
@@ -165,12 +165,13 @@
         "qs_pg:id":247831,
         "wd:id":"Q837035"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010197,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"85939468d03c139e5b003c55768056d2",
+    "wof:geomhash":"c1fda286731a50c47d536946161e279c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":421204771,
-    "wof:lastmodified":1690927676,
+    "wof:lastmodified":1695886027,
     "wof:name":"Totonicapan",
     "wof:parent_id":85671697,
     "wof:placetype":"county",

--- a/data/421/205/243/421205243.geojson
+++ b/data/421/205/243/421205243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006831,
-    "geom:area_square_m":81687992.38452,
+    "geom:area_square_m":81687926.344749,
     "geom:bbox":"-89.481875,14.691914,-89.362293,14.794297",
     "geom:latitude":14.734249,
     "geom:longitude":-89.426454,
@@ -126,12 +126,13 @@
         "wd:id":"Q2025266",
         "wk:page":"San Juan Ermita"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GT",
     "wof:created":1459010216,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"26e4c7a5e636f374f054fd7d116089cb",
+    "wof:geomhash":"1a2ddd307bbe00d3e326bb8593bc2903",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421205243,
-    "wof:lastmodified":1690927688,
+    "wof:lastmodified":1695886027,
     "wof:name":"San Juan Ermita",
     "wof:parent_id":85671715,
     "wof:placetype":"county",

--- a/data/856/323/85/85632385.geojson
+++ b/data/856/323/85/85632385.geojson
@@ -1190,6 +1190,7 @@
         "hasc:id":"GT",
         "icao:code":"TG",
         "ioc:id":"GUA",
+        "iso:code":"GT",
         "itu:id":"GTM",
         "loc:id":"n79054016",
         "m49:code":"320",
@@ -1204,6 +1205,7 @@
         "wk:page":"Guatemala",
         "wmo:id":"GU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:country_alpha3":"GTM",
     "wof:geom_alt":[
@@ -1227,7 +1229,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1694639644,
+    "wof:lastmodified":1695881306,
     "wof:name":"Guatemala",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/716/35/85671635.geojson
+++ b/data/856/716/35/85671635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252305,
-    "geom:area_square_m":3011834065.811239,
+    "geom:area_square_m":3011834113.923815,
     "geom:bbox":"-90.815559,14.869779,-89.855595,15.350619",
     "geom:latitude":15.117017,
     "geom:longitude":-90.384978,
@@ -313,17 +313,19 @@
         "gn:id":3599602,
         "gp:id":2345553,
         "hasc:id":"GT.BV",
+        "iso:code":"GT-BV",
         "iso:id":"GT-BV",
         "qs_pg:id":442529,
         "unlc:id":"GT-BV",
         "wd:id":"Q504647",
         "wk:page":"Baja Verapaz Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b95eb471e2807a4dc4eb8e4fde4cb468",
+    "wof:geomhash":"b8d8ae9173379b323bdd491637527cb8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -339,7 +341,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927561,
+    "wof:lastmodified":1695884951,
     "wof:name":"Baja Verapaz",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/41/85671641.geojson
+++ b/data/856/716/41/85671641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.623718,
-    "geom:area_square_m":7426318524.784199,
+    "geom:area_square_m":7426318135.11048,
     "geom:bbox":"-92.115895,15.134357,-91.043787,16.076909",
     "geom:latitude":15.651786,
     "geom:longitude":-91.560921,
@@ -304,17 +304,19 @@
         "gn:id":3595415,
         "gp:id":2345559,
         "hasc:id":"GT.HU",
+        "iso:code":"GT-HU",
         "iso:id":"GT-HU",
         "qs_pg:id":1168653,
         "unlc:id":"GT-HU",
         "wd:id":"Q842266",
         "wk:page":"Huehuetenango Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5533322672eed1513504eef56fbcefd",
+    "wof:geomhash":"82693b8e13338404fba25abda15f1122",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -330,7 +332,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927564,
+    "wof:lastmodified":1695884952,
     "wof:name":"Huehuetenango",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/47/85671647.geojson
+++ b/data/856/716/47/85671647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.043971,
-    "geom:area_square_m":35997370015.385002,
+    "geom:area_square_m":35997369426.773384,
     "geom:bbox":"-91.439715,15.847581,-89.150078,17.815687",
     "geom:latitude":16.978491,
     "geom:longitude":-90.020208,
@@ -317,17 +317,19 @@
         "gn:id":3591410,
         "gp:id":2345563,
         "hasc:id":"GT.PE",
+        "iso:code":"GT-PE",
         "iso:id":"GT-PE",
         "qs_pg:id":1168655,
         "unlc:id":"GT-PE",
         "wd:id":"Q466061",
         "wk:page":"Pet\u00e9n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"da6f0c564ae383de2f6ccdfe488aee16",
+    "wof:geomhash":"90da3ef3a4b69832f5d2f5e338ec127e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -343,7 +345,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927566,
+    "wof:lastmodified":1695884374,
     "wof:name":"Pet\u00e9n",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/51/85671651.geojson
+++ b/data/856/716/51/85671651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.179273,
-    "geom:area_square_m":2143316895.920167,
+    "geom:area_square_m":2143316709.985283,
     "geom:bbox":"-92.141446,14.491507,-91.403835,15.229041",
     "geom:latitude":14.788018,
     "geom:longitude":-91.713578,
@@ -310,17 +310,19 @@
         "gn:id":3590978,
         "gp:id":2345564,
         "hasc:id":"GT.QZ",
+        "iso:code":"GT-QZ",
         "iso:id":"GT-QZ",
         "qs_pg:id":1168656,
         "unlc:id":"GT-QZ",
         "wd:id":"Q844502",
         "wk:page":"Quetzaltenango Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4a1f9872555ecb871ec2b4634ff983f4",
+    "wof:geomhash":"d7c3bcd73639c6e1cef2d9f64a2ac5d8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -336,7 +338,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927562,
+    "wof:lastmodified":1695884951,
     "wof:name":"Quezaltenango",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/59/85671659.geojson
+++ b/data/856/716/59/85671659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142407,
-    "geom:area_square_m":1705225980.602074,
+    "geom:area_square_m":1705225806.087824,
     "geom:bbox":"-92.171987,14.187542,-91.542813,14.713329",
     "geom:latitude":14.444489,
     "geom:longitude":-91.804377,
@@ -309,17 +309,19 @@
         "gn:id":3590857,
         "gp:id":2345566,
         "hasc:id":"GT.RE",
+        "iso:code":"GT-RE",
         "iso:id":"GT-RE",
         "qs_pg:id":672870,
         "unlc:id":"GT-RE",
         "wd:id":"Q888307",
         "wk:page":"Retalhuleu"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ebaa77a1b196b4348fb77e610cbfe514",
+    "wof:geomhash":"decb8577b2c2ef74df0371dce7b0d1ac",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +337,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927561,
+    "wof:lastmodified":1695884951,
     "wof:name":"Retalhuleu",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/61/85671661.geojson
+++ b/data/856/716/61/85671661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298562,
-    "geom:area_square_m":3565641264.970304,
+    "geom:area_square_m":3565642310.7259,
     "geom:bbox":"-92.231153,14.489957,-91.565782,15.42196",
     "geom:latitude":15.018918,
     "geom:longitude":-91.93148,
@@ -316,17 +316,19 @@
         "gn:id":3589801,
         "gp:id":2345568,
         "hasc:id":"GT.SM",
+        "iso:code":"GT-SM",
         "iso:id":"GT-SM",
         "qs_pg:id":1117347,
         "unlc:id":"GT-SM",
         "wd:id":"Q883907",
         "wk:page":"San Marcos Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"659c3ddeb6d224d67be38cc12b7e202a",
+    "wof:geomhash":"fcf5cdce543580214962a98e456e0cfa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -342,7 +344,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927560,
+    "wof:lastmodified":1695884951,
     "wof:name":"San Marcos",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/65/85671665.geojson
+++ b/data/856/716/65/85671665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.893184,
-    "geom:area_square_m":10635394702.364912,
+    "geom:area_square_m":10635394396.223068,
     "geom:bbox":"-90.817891,15.117025,-89.412252,16.073305",
     "geom:latitude":15.639937,
     "geom:longitude":-90.101157,
@@ -319,17 +319,19 @@
         "gn:id":3599773,
         "gp:id":2345552,
         "hasc:id":"GT.AV",
+        "iso:code":"GT-AV",
         "iso:id":"GT-AV",
         "qs_pg:id":890067,
         "unlc:id":"GT-AV",
         "wd:id":"Q504637",
         "wk:page":"Alta Verapaz Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b40c738ed13c9df1cd905c6bae9a1f7c",
+    "wof:geomhash":"dbcd3eae74ae6668a6a103422e9406cd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -345,7 +347,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927563,
+    "wof:lastmodified":1695884952,
     "wof:name":"Alta Verapaz",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/71/85671671.geojson
+++ b/data/856/716/71/85671671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.156294,
-    "geom:area_square_m":1869375762.105119,
+    "geom:area_square_m":1869375605.582183,
     "geom:bbox":"-91.128217,14.380381,-90.619227,14.937722",
     "geom:latitude":14.695447,
     "geom:longitude":-90.922014,
@@ -306,17 +306,19 @@
         "gn:id":3598571,
         "gp:id":2345554,
         "hasc:id":"GT.CM",
+        "iso:code":"GT-CM",
         "iso:id":"GT-CM",
         "qs_pg:id":318487,
         "unlc:id":"GT-CM",
         "wd:id":"Q765975",
         "wk:page":"Chimaltenango Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8f67580460db86205813e3a9af24c4a7",
+    "wof:geomhash":"ab1fd8364c77ff27e8f9a90f0fa417da",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -332,7 +334,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927566,
+    "wof:lastmodified":1695884952,
     "wof:name":"Chimaltenango",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/77/85671677.geojson
+++ b/data/856/716/77/85671677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.376877,
-    "geom:area_square_m":4518480648.26969,
+    "geom:area_square_m":4518480308.374207,
     "geom:bbox":"-91.537831,13.913028,-90.579548,14.470981",
     "geom:latitude":14.163571,
     "geom:longitude":-91.009243,
@@ -322,17 +322,19 @@
         "gn:id":3595802,
         "gp:id":2345557,
         "hasc:id":"GT.ES",
+        "iso:code":"GT-ES",
         "iso:id":"GT-ES",
         "qs_pg:id":890068,
         "unlc:id":"GT-ES",
         "wd:id":"Q795587",
         "wk:page":"Escuintla Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a73b6879d47716602abdae6cfff295fa",
+    "wof:geomhash":"2edd84600446d41d54bc1a8c4cb8d2db",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -348,7 +350,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927565,
+    "wof:lastmodified":1695884952,
     "wof:name":"Escuintla",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/81/85671681.geojson
+++ b/data/856/716/81/85671681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185195,
-    "geom:area_square_m":2215738901.062276,
+    "geom:area_square_m":2215738894.766005,
     "geom:bbox":"-90.767836,14.249084,-90.215502,14.916759",
     "geom:latitude":14.628097,
     "geom:longitude":-90.494717,
@@ -319,16 +319,18 @@
         "gn:id":3595530,
         "gp:id":2345558,
         "hasc:id":"GT.GU",
+        "iso:code":"GT-GU",
         "iso:id":"GT-GU",
         "qs_pg:id":890069,
         "wd:id":"Q695660",
         "wk:page":"Guatemala Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"83fd0e8297db24591506dc5f7f51b1c0",
+    "wof:geomhash":"1fe0b84e66e15978caf740880d3cd1e8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -344,7 +346,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927563,
+    "wof:lastmodified":1695884952,
     "wof:name":"Guatemala",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/83/85671683.geojson
+++ b/data/856/716/83/85671683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.201675,
-    "geom:area_square_m":2415612112.518136,
+    "geom:area_square_m":2415612160.639472,
     "geom:bbox":"-91.783044,14.043006,-91.089162,14.698247",
     "geom:latitude":14.380435,
     "geom:longitude":-91.430874,
@@ -307,17 +307,19 @@
         "gn:id":3588668,
         "gp:id":2345571,
         "hasc:id":"GT.SU",
+        "iso:code":"GT-SU",
         "iso:id":"GT-SU",
         "qs_pg:id":59613,
         "unlc:id":"GT-SU",
         "wd:id":"Q883734",
         "wk:page":"Suchitep\u00e9quez Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0f87a8033c69f32a34bbb1b3a381180",
+    "wof:geomhash":"aa0950deb92e200b08192aab67c900cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927565,
+    "wof:lastmodified":1695884374,
     "wof:name":"Suchitep\u00e9quez",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/87/85671687.geojson
+++ b/data/856/716/87/85671687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045005,
-    "geom:area_square_m":538641183.960289,
+    "geom:area_square_m":538641075.620666,
     "geom:bbox":"-90.881611,14.391057,-90.61181,14.721835",
     "geom:latitude":14.551741,
     "geom:longitude":-90.746669,
@@ -315,17 +315,19 @@
         "gn:id":3590686,
         "gp:id":2345567,
         "hasc:id":"GT.SA",
+        "iso:code":"GT-SA",
         "iso:id":"GT-SA",
         "qs_pg:id":1117346,
         "unlc:id":"GT-SA",
         "wd:id":"Q508804",
         "wk:page":"Sacatep\u00e9quez Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0928cf1277d0d0de14d8390095f4b0b6",
+    "wof:geomhash":"a1e0b47db76d929e1e714c7eae7258c2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -341,7 +343,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927562,
+    "wof:lastmodified":1695884374,
     "wof:name":"Sacatepequez",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/95/85671695.geojson
+++ b/data/856/716/95/85671695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098185,
-    "geom:area_square_m":1174244573.56716,
+    "geom:area_square_m":1174245001.695321,
     "geom:bbox":"-91.504305,14.518313,-91.072415,14.896922",
     "geom:latitude":14.717059,
     "geom:longitude":-91.262627,
@@ -303,17 +303,19 @@
         "gn:id":3588697,
         "gp:id":2345570,
         "hasc:id":"GT.SO",
+        "iso:code":"GT-SO",
         "iso:id":"GT-SO",
         "qs_pg:id":890071,
         "unlc:id":"GT-SO",
         "wd:id":"Q178136",
         "wk:page":"Solol\u00e1 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f569468143029a185cb039325e62f352",
+    "wof:geomhash":"d9c4640ecca3dfce0d56d57174f4c5b2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927560,
+    "wof:lastmodified":1695884374,
     "wof:name":"Solol\u00e1",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/716/97/85671697.geojson
+++ b/data/856/716/97/85671697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09066,
-    "geom:area_square_m":1082745120.073761,
+    "geom:area_square_m":1082744903.366563,
     "geom:bbox":"-91.550927,14.823754,-91.179002,15.24591",
     "geom:latitude":15.015797,
     "geom:longitude":-91.377428,
@@ -306,17 +306,19 @@
         "gn:id":3588257,
         "gp:id":2345572,
         "hasc:id":"GT.TO",
+        "iso:code":"GT-TO",
         "iso:id":"GT-TO",
         "qs_pg:id":890072,
         "unlc:id":"GT-TO",
         "wd:id":"Q885644",
         "wk:page":"Totonicap\u00e1n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ba30400e5c54363e3ce8cbedd78f0e14",
+    "wof:geomhash":"cdb2de1a73ca6ba49b84583f6f7138a4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -332,7 +334,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927564,
+    "wof:lastmodified":1695884374,
     "wof:name":"Totonicap\u00e1n",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/01/85671701.geojson
+++ b/data/856/717/01/85671701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154383,
-    "geom:area_square_m":1844728207.319571,
+    "geom:area_square_m":1844728693.81895,
     "geom:bbox":"-90.406889,14.666253,-89.789664,15.154797",
     "geom:latitude":14.90694,
     "geom:longitude":-90.082828,
@@ -307,17 +307,19 @@
         "gn:id":3596416,
         "gp:id":2345556,
         "hasc:id":"GT.PR",
+        "iso:code":"GT-PR",
         "iso:id":"GT-PR",
         "qs_pg:id":1000432,
         "unlc:id":"GT-PR",
         "wd:id":"Q795591",
         "wk:page":"El Progreso Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2957cbcf02d12434291635fc6f6bee37",
+    "wof:geomhash":"2f9955e60d97176b6985cad92ae43962",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927558,
+    "wof:lastmodified":1695884951,
     "wof:name":"El Progreso",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/05/85671705.geojson
+++ b/data/856/717/05/85671705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265321,
-    "geom:area_square_m":3181074961.739553,
+    "geom:area_square_m":3181075029.352757,
     "geom:bbox":"-90.673865,13.791675,-90.057633,14.506048",
     "geom:latitude":14.158342,
     "geom:longitude":-90.355943,
@@ -315,17 +315,19 @@
         "gn:id":3589172,
         "gp:id":2345569,
         "hasc:id":"GT.SR",
+        "iso:code":"GT-SR",
         "iso:id":"GT-SR",
         "qs_pg:id":890070,
         "unlc:id":"GT-SR",
         "wd:id":"Q885656",
         "wk:page":"Santa Rosa Department, Guatemala"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd7f190d7a8f2b07dcd798ee7bdbfb83",
+    "wof:geomhash":"1ee123ce688b4172285f8092fd6611fd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -341,7 +343,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927556,
+    "wof:lastmodified":1695884951,
     "wof:name":"Santa Rosa",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/09/85671709.geojson
+++ b/data/856/717/09/85671709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.695021,
-    "geom:area_square_m":8279230203.084889,
+    "geom:area_square_m":8279230369.571094,
     "geom:bbox":"-89.623931,15.068382,-88.231057,15.967361",
     "geom:latitude":15.555485,
     "geom:longitude":-89.006892,
@@ -307,17 +307,19 @@
         "gn:id":3595259,
         "gp:id":2345560,
         "hasc:id":"GT.IZ",
+        "iso:code":"GT-IZ",
         "iso:id":"GT-IZ",
         "qs_pg:id":1168654,
         "unlc:id":"GT-IZ",
         "wd:id":"Q693658",
         "wk:page":"Izabal Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"55ab01a09c712dc177601296b608d3e5",
+    "wof:geomhash":"9ebfc2049ec67be615eda6be14e752ab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927558,
+    "wof:lastmodified":1695884951,
     "wof:name":"Izabal",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/15/85671715.geojson
+++ b/data/856/717/15/85671715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.200912,
-    "geom:area_square_m":2403124973.80409,
+    "geom:area_square_m":2403124425.53243,
     "geom:bbox":"-89.716908,14.406041,-89.132271,14.952305",
     "geom:latitude":14.688243,
     "geom:longitude":-89.42482,
@@ -306,17 +306,19 @@
         "gn:id":3598464,
         "gp:id":2345555,
         "hasc:id":"GT.CQ",
+        "iso:code":"GT-CQ",
         "iso:id":"GT-CQ",
         "qs_pg:id":59607,
         "unlc:id":"GT-CQ",
         "wd:id":"Q753037",
         "wk:page":"Chiquimula Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8aa6a8f0e6ab01be3298efbc85788a80",
+    "wof:geomhash":"1b38af55dde89aa32f5e89e521417bed",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -332,7 +334,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927559,
+    "wof:lastmodified":1695884951,
     "wof:name":"Chiquimula",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/19/85671719.geojson
+++ b/data/856/717/19/85671719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169597,
-    "geom:area_square_m":2029182071.403852,
+    "geom:area_square_m":2029181826.692876,
     "geom:bbox":"-90.291248,14.416857,-89.64543,14.875513",
     "geom:latitude":14.620901,
     "geom:longitude":-89.947057,
@@ -307,17 +307,19 @@
         "gn:id":3595236,
         "gp:id":2345561,
         "hasc:id":"GT.JA",
+        "iso:code":"GT-JA",
         "iso:id":"GT-JA",
         "qs_pg:id":229375,
         "unlc:id":"GT-JA",
         "wd:id":"Q795441",
         "wk:page":"Jalapa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"72b44b94e2747aee7183e64e752ecadc",
+    "wof:geomhash":"f1009217e4563bf48c65ff6573be826b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927557,
+    "wof:lastmodified":1695884951,
     "wof:name":"Jalapa",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/23/85671723.geojson
+++ b/data/856/717/23/85671723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.276764,
-    "geom:area_square_m":3317499333.349117,
+    "geom:area_square_m":3317500068.466253,
     "geom:bbox":"-90.296258,13.740028,-89.494836,14.559284",
     "geom:latitude":14.210575,
     "geom:longitude":-89.89873,
@@ -315,17 +315,19 @@
         "gn:id":3595067,
         "gp:id":2345562,
         "hasc:id":"GT.JU",
+        "iso:code":"GT-JU",
         "iso:id":"GT-JU",
         "qs_pg:id":672806,
         "unlc:id":"GT-JU",
         "wd:id":"Q765984",
         "wk:page":"Jutiapa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"abd586499f2e673628077d83949a34e2",
+    "wof:geomhash":"956ae54e59a16d21e21696e4a6e6b1dc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -341,7 +343,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927559,
+    "wof:lastmodified":1695884951,
     "wof:name":"Jutiapa",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/27/85671727.geojson
+++ b/data/856/717/27/85671727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.227325,
-    "geom:area_square_m":2714663387.517654,
+    "geom:area_square_m":2714663488.312667,
     "geom:bbox":"-89.899118,14.739007,-89.152499,15.29765",
     "geom:latitude":15.037279,
     "geom:longitude":-89.508388,
@@ -300,17 +300,19 @@
         "gn:id":3587586,
         "gp:id":2345573,
         "hasc:id":"GT.ZA",
+        "iso:code":"GT-ZA",
         "iso:id":"GT-ZA",
         "qs_pg:id":479602,
         "unlc:id":"GT-ZA",
         "wd:id":"Q780784",
         "wk:page":"Zacapa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1768f4d0f16cde813b222f6ff360e3e",
+    "wof:geomhash":"83e611437b9abf411da48f45b8df8144",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -326,7 +328,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927557,
+    "wof:lastmodified":1695884951,
     "wof:name":"Zacapa",
     "wof:parent_id":85632385,
     "wof:placetype":"region",

--- a/data/856/717/33/85671733.geojson
+++ b/data/856/717/33/85671733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.614835,
-    "geom:area_square_m":7327521378.727072,
+    "geom:area_square_m":7327520112.979621,
     "geom:bbox":"-91.326061,14.779427,-90.422144,16.077345",
     "geom:latitude":15.454914,
     "geom:longitude":-90.94815,
@@ -303,17 +303,19 @@
         "gn:id":3590964,
         "gp:id":2345565,
         "hasc:id":"GT.QC",
+        "iso:code":"GT-QC",
         "iso:id":"GT-QC",
         "qs_pg:id":1168657,
         "unlc:id":"GT-QC",
         "wd:id":"Q669802",
         "wk:page":"Quich\u00e9 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"500ae552dcc70aba89426c9853e068b0",
+    "wof:geomhash":"3e7b181e1c660b6a3cc7519e5e521d61",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
         "spa",
         "quc"
     ],
-    "wof:lastmodified":1690927556,
+    "wof:lastmodified":1695884374,
     "wof:name":"Quich\u00e9",
     "wof:parent_id":85632385,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.